### PR TITLE
Platform: Desktop Implementaiton

### DIFF
--- a/FinalEngine.Logging/Handlers/TextWriterLogHandler.cs
+++ b/FinalEngine.Logging/Handlers/TextWriterLogHandler.cs
@@ -47,6 +47,7 @@
             {
                 throw new ArgumentNullException(nameof(message), $"The specified { nameof(message) } parameter is null.");
             }
+
             writer.WriteLine(Formatter.GetFormattedLog(type, message));
         }
     }

--- a/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
+++ b/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
+++ b/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
@@ -1,7 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTK.NetStandard" Version="1.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Platform\FinalEngine.Platform.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/FinalEngine.Platform.Desktop/OpenTKDisplay.cs
+++ b/FinalEngine.Platform.Desktop/OpenTKDisplay.cs
@@ -1,5 +1,6 @@
 ﻿namespace FinalEngine.Platform.Desktop
 {
+    using System;
     using System.ComponentModel;
     using System.Drawing;
 
@@ -28,6 +29,12 @@
             Width = width;
             Height = height;
             Title = title;
+
+            // TODO: this probably shouldn't be in the constructor?
+            OpenTK.Rectangle workingArea = OpenTK.DisplayDevice.Default.Bounds;
+
+            X = Math.Max(workingArea.X, workingArea.X + ((workingArea.Width - Width) / 2));
+            Y = Math.Max(workingArea.Y, workingArea.Y + ((workingArea.Height - Height) / 2));
         }
 
         /// <summary>

--- a/FinalEngine.Platform.Desktop/OpenTKDisplay.cs
+++ b/FinalEngine.Platform.Desktop/OpenTKDisplay.cs
@@ -1,0 +1,110 @@
+﻿namespace FinalEngine.Platform.Desktop
+{
+    using System.ComponentModel;
+    using System.Drawing;
+
+    /// <summary>
+    ///   Provides an <see cref="OpenTK.NativeWindow"/> implementation of an <see cref="IDisplay"/> and <see cref="IEventsProcessor"/>.
+    /// </summary>
+    /// <seealso cref="OpenTK.NativeWindow"/>
+    /// <seealso cref="FinalEngine.Platform.IDisplay"/>
+    /// <seealso cref="FinalEngine.Platform.IEventsProcessor"/>
+    public sealed class OpenTKDisplay : OpenTK.NativeWindow, IDisplay, IEventsProcessor
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="OpenTKDisplay"/> class.
+        /// </summary>
+        /// <param name="width">
+        ///   Specifies the width (in pixels) of this <see cref="OpenTKDisplay"/>.
+        /// </param>
+        /// <param name="height">
+        ///   Specifies the height (in pixels) of this <see cref="OpenTKDisplay"/>.
+        /// </param>
+        /// <param name="title">
+        ///   Specifies the title of this <see cref="OpenTKDisplay"/>.
+        /// </param>
+        public OpenTKDisplay(int width, int height, string title)
+        {
+            Width = width;
+            Height = height;
+            Title = title;
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="Rectangle"/> that represents the internal bounds of this <see cref="OpenTKDisplay"/>.
+        /// </summary>
+        /// <value>
+        ///   The internal bounds of this <see cref="OpenTKDisplay"/>.
+        /// </value>
+        Rectangle IDisplay.ClientRectangle
+        {
+            get { return new Rectangle(ClientRectangle.X, ClientRectangle.Y, ClientRectangle.Width, ClientRectangle.Height); }
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="Size"/> that represents the internal size of this <see cref="OpenTKDisplay"/>.
+        /// </summary>
+        /// <value>
+        ///   The internal size of this <see cref="OpenTKDisplay"/>.
+        /// </value>
+        Size IDisplay.ClientSize
+        {
+            get { return new Size(ClientSize.Width, ClientSize.Height); }
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="bool"/> indicating whether this <see cref="OpenTKDisplay"/> is closing.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this <see cref="OpenTKDisplay"/> is closing; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsClosing { get; private set; }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="Point"/> structure that contains the location of this <see cref="OpenTKDisplay"/> on the desktop.
+        /// </summary>
+        Point IDisplay.Location
+        {
+            get
+            {
+                return new Point(X, Y);
+            }
+
+            set
+            {
+                X = value.X;
+                Y = value.Y;
+            }
+        }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="Size"/> structure that contains the external size of this <see cref="OpenTKDisplay"/>.
+        /// </summary>
+        Size IDisplay.Size
+        {
+            get
+            {
+                return new Size(Width, Height);
+            }
+
+            set
+            {
+                Width = value.Width;
+                Height = value.Height;
+            }
+        }
+
+        /// <summary>
+        ///   Called when the <see cref="OpenTKDisplay"/> is about to close.
+        /// </summary>
+        /// <param name="e">
+        ///   The <see cref="T:System.ComponentModel.CancelEventArgs"/> for this event. Set e.Cancel to true in order to stop the <see cref="OpenTKDisplay"/> from closing.
+        /// </param>
+        protected override void OnClosing(CancelEventArgs e)
+        {
+            IsClosing = !e.Cancel;
+
+            base.OnClosing(e);
+        }
+    }
+}

--- a/FinalEngine.Platform.Desktop/Settings.StyleCop
+++ b/FinalEngine.Platform.Desktop/Settings.StyleCop
@@ -37,6 +37,11 @@
             <BooleanProperty Name="Enabled">False</BooleanProperty>
           </RuleSettings>
         </Rule>
+        <Rule Name="PropertySummaryDocumentationMustMatchAccessors">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
       </Rules>
       <AnalyzerSettings />
     </Analyzer>

--- a/FinalEngine.Platform.Desktop/Settings.StyleCop
+++ b/FinalEngine.Platform.Desktop/Settings.StyleCop
@@ -1,0 +1,69 @@
+<StyleCopSettings Version="105">
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="FileMustHaveHeader">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustShowCopyright">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveCopyrightText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustContainFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveValidCompanyText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchTypeName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
+      <Rules>
+        <Rule Name="PrefixLocalCallsWithThis">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PrefixCallsCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.SpacingRules">
+      <Rules>
+        <Rule Name="TabsMustNotBeUsed">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>

--- a/FinalEngine.Sandbox.Desktop/FinalEngine.Sandbox.Desktop.csproj
+++ b/FinalEngine.Sandbox.Desktop/FinalEngine.Sandbox.Desktop.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Platform.Desktop\FinalEngine.Platform.Desktop.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FinalEngine.Sandbox.Desktop/Program.cs
+++ b/FinalEngine.Sandbox.Desktop/Program.cs
@@ -1,0 +1,35 @@
+﻿namespace FinalEngine.Sandbox.Desktop
+{
+    using FinalEngine.Platform.Desktop;
+
+    /// <summary>
+    ///   The main program.
+    /// </summary>
+    internal static class Program
+    {
+        /// <summary>
+        ///   Defines the entry point of the application.
+        /// </summary>
+        /// <param name="args">
+        ///   Specifies the args.
+        /// </param>
+        private static void Main(string[] args)
+        {
+            const int WindowWidth = 1024;
+            const int WindowHeight = 768;
+            const string WindowTItle = "Final Engine on Desktop";
+
+            var display = new OpenTKDisplay(WindowWidth, WindowHeight, WindowTItle)
+            {
+                Visible = true
+            };
+
+            while (!display.IsClosing)
+            {
+                display.ProcessEvents();
+            }
+
+            display.Dispose();
+        }
+    }
+}

--- a/FinalEngine.Sandbox.Desktop/Settings.StyleCop
+++ b/FinalEngine.Sandbox.Desktop/Settings.StyleCop
@@ -1,0 +1,69 @@
+<StyleCopSettings Version="105">
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="FileMustHaveHeader">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustShowCopyright">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveCopyrightText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustContainFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveValidCompanyText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchTypeName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
+      <Rules>
+        <Rule Name="PrefixLocalCallsWithThis">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PrefixCallsCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.SpacingRules">
+      <Rules>
+        <Rule Name="TabsMustNotBeUsed">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>

--- a/FinalEngine.sln
+++ b/FinalEngine.sln
@@ -15,9 +15,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Platform", "Platform", "{F3
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Platform", "FinalEngine.Platform\FinalEngine.Platform.csproj", "{5FFEBEFC-408A-4335-BC8D-FE5EF4E81263}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Logging", "FinalEngine.Logging\FinalEngine.Logging.csproj", "{DDB8EF7C-B53E-4EA7-9C75-C78BFD5FCA22}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Logging", "FinalEngine.Logging\FinalEngine.Logging.csproj", "{DDB8EF7C-B53E-4EA7-9C75-C78BFD5FCA22}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Logging.Tests", "FinalEngine.Logging.Tests\FinalEngine.Logging.Tests.csproj", "{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Logging.Tests", "FinalEngine.Logging.Tests\FinalEngine.Logging.Tests.csproj", "{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Platform.Desktop", "FinalEngine.Platform.Desktop\FinalEngine.Platform.Desktop.csproj", "{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -89,6 +91,18 @@ Global
 		{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554}.Release|x64.Build.0 = Release|Any CPU
 		{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554}.Release|x86.ActiveCfg = Release|Any CPU
 		{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554}.Release|x86.Build.0 = Release|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Debug|x64.Build.0 = Debug|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Debug|x86.Build.0 = Debug|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|x64.ActiveCfg = Release|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|x64.Build.0 = Release|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|x86.ActiveCfg = Release|Any CPU
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -100,6 +114,7 @@ Global
 		{5FFEBEFC-408A-4335-BC8D-FE5EF4E81263} = {F352E63D-4DFC-488A-A41E-A066C4994AA8}
 		{DDB8EF7C-B53E-4EA7-9C75-C78BFD5FCA22} = {D4445AC7-89F7-4DDE-A59C-089BE8360C23}
 		{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554} = {630A1D15-42F7-444E-A7EC-96271CD4DE8C}
+		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7} = {F352E63D-4DFC-488A-A41E-A066C4994AA8}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A278B383-0D14-41B3-A71C-4505E1D503DF}

--- a/FinalEngine.sln
+++ b/FinalEngine.sln
@@ -21,6 +21,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Logging.Tests",
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Platform.Desktop", "FinalEngine.Platform.Desktop\FinalEngine.Platform.Desktop.csproj", "{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sandbox", "Sandbox", "{A6D0464A-3797-428D-8E93-91EF7779E761}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Sandbox.Desktop", "FinalEngine.Sandbox.Desktop\FinalEngine.Sandbox.Desktop.csproj", "{3A71EEE9-7839-44BF-A151-924E0E0623A0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -103,6 +107,18 @@ Global
 		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|x64.Build.0 = Release|Any CPU
 		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|x86.ActiveCfg = Release|Any CPU
 		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}.Release|x86.Build.0 = Release|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Debug|x64.Build.0 = Debug|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Debug|x86.Build.0 = Debug|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|x64.ActiveCfg = Release|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|x64.Build.0 = Release|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|x86.ActiveCfg = Release|Any CPU
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -115,6 +131,7 @@ Global
 		{DDB8EF7C-B53E-4EA7-9C75-C78BFD5FCA22} = {D4445AC7-89F7-4DDE-A59C-089BE8360C23}
 		{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554} = {630A1D15-42F7-444E-A7EC-96271CD4DE8C}
 		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7} = {F352E63D-4DFC-488A-A41E-A066C4994AA8}
+		{3A71EEE9-7839-44BF-A151-924E0E0623A0} = {A6D0464A-3797-428D-8E93-91EF7779E761}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A278B383-0D14-41B3-A71C-4505E1D503DF}


### PR DESCRIPTION
# Disclaimer

This PR introduces a new dependency; [OpenTK .NET Standard 1.0.4](https://www.nuget.org/packages/OpenTK.NetStandard/). OpenTK .NET Standard is **not** an official fork or .NET Standard implementation. However, using this dependency seems like the best option for FE, at least now. OpenTK 4.0 won't be release for a while but once it is the following issues can be resolved:

- OpenTK 4.0 won't have a monolithic nature, so projects won't have to reference the entirely of OpenTK just for simple things like handling input.
- OpenTK 4.0 will be using GLFW; as a result the code introduced in this PR will more than likely change, _allot_.
- ~~OpenTK 4.0 will be using the `System.Drawing` namespace, instead of providing its own `Point` and `Rectangle` structures.~~ Turns out, this is not the case due to `System.Drawing` in .NET Standard still requiring access to GDI+.

# Description

In order for #13 to be closed, we should first close #6. In this PR I've provided a **very simple** class that allows us to create a window on .NET Core across Windows, Macintosh and Linux operating systems.

Fixes #6 

## Dependencies

- [OpenTK .NET Standard 1.0.4](https://www.nuget.org/packages/OpenTK.NetStandard/)

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I have not provided any unit tests as the code in this PR is only temporary until the release of OpenTK 4.0. On top of that, unit testing code like this has proved difficult time and time again. Given that the code relies heavily on OpenTK and the rest is all just properties and fields; it doesn't _really_ need to be tested.

### Pseudo Code

You can en example of the code working [here](https://github.com/mtosoftware/FinalEngine/blob/feature-platform-desktop/FinalEngine.Sandbox.Desktop/Program.cs).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x]  I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
