### PR TITLE
Drawing Primitives Library

### DIFF
--- a/FinalEngine.Drawing.Tests/FinalEngine.Drawing.Tests.csproj
+++ b/FinalEngine.Drawing.Tests/FinalEngine.Drawing.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.10.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Drawing\FinalEngine.Drawing.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FinalEngine.Drawing.Tests/PointFTests.cs
+++ b/FinalEngine.Drawing.Tests/PointFTests.cs
@@ -1,0 +1,114 @@
+﻿namespace FinalEngine.Drawing.Tests
+{
+    using NUnit.Framework;
+
+    public sealed class PointFTests
+    {
+        [Test]
+        public void Empty_ReadOnly_Field_Test()
+        {
+            // Arrange
+            var expected = new PointF(0, 0);
+
+            // Act
+            PointF actual = PointF.Empty;
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_PointF()
+        {
+            // Arrange
+            var point = new PointF(0, 0);
+            object obj = new object();
+
+            // Act
+            bool result = point.Equals(obj);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Same_Values()
+        {
+            // Arrange
+            var left = new PointF(100, 100);
+            var right = new PointF(200, 200);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_True_When_Same_Values()
+        {
+            // Arrange
+            var left = new PointF(156, 245);
+            var right = new PointF(156, 245);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_False()
+        {
+            // Arrange
+            var point = new PointF(100, 140);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_True()
+        {
+            // Arrange
+            var point = new PointF(0, 0);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void X_Property_Test_Should_Be_45()
+        {
+            // Arrange
+            const float Expected = 45.0f;
+
+            // Act
+            var point = new PointF(Expected, 0);
+
+            // Assert
+            Assert.AreEqual(Expected, point.X);
+        }
+
+        [Test]
+        public void Y_Property_Test_Should_Be_68()
+        {
+            // Arrange
+            const float Expected = 68.0f;
+
+            // Act
+            var point = new PointF(0, Expected);
+
+            // Assert
+            Assert.AreEqual(Expected, point.Y);
+        }
+    }
+}

--- a/FinalEngine.Drawing.Tests/PointTests.cs
+++ b/FinalEngine.Drawing.Tests/PointTests.cs
@@ -1,0 +1,114 @@
+﻿namespace FinalEngine.Drawing.Tests
+{
+    using NUnit.Framework;
+
+    public sealed class PointTests
+    {
+        [Test]
+        public void Empty_ReadOnly_Field_Test()
+        {
+            // Arrange
+            var expected = new Point(0, 0);
+
+            // Act
+            Point actual = Point.Empty;
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Point()
+        {
+            // Arrange
+            var point = new Point(0, 0);
+            object obj = new object();
+
+            // Act
+            bool result = point.Equals(obj);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Same_Values()
+        {
+            // Arrange
+            var left = new Point(100, 100);
+            var right = new Point(200, 200);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_True_When_Same_Values()
+        {
+            // Arrange
+            var left = new Point(156, 245);
+            var right = new Point(156, 245);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_False()
+        {
+            // Arrange
+            var point = new Point(100, 140);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_True()
+        {
+            // Arrange
+            var point = new Point(0, 0);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void X_Property_Test_Should_Be_45()
+        {
+            // Arrange
+            const int Expected = 45;
+
+            // Act
+            var point = new Point(Expected, 0);
+
+            // Assert
+            Assert.AreEqual(Expected, point.X);
+        }
+
+        [Test]
+        public void Y_Property_Test_Should_Be_68()
+        {
+            // Arrange
+            const int Expected = 68;
+
+            // Act
+            var point = new Point(0, Expected);
+
+            // Assert
+            Assert.AreEqual(Expected, point.Y);
+        }
+    }
+}

--- a/FinalEngine.Drawing.Tests/RectangleFTests.cs
+++ b/FinalEngine.Drawing.Tests/RectangleFTests.cs
@@ -1,0 +1,131 @@
+﻿namespace FinalEngine.Drawing.Tests
+{
+    using NUnit.Framework;
+
+    public sealed class RectangleFTests
+    {
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_RectangleF()
+        {
+            // Arrange
+            var rectangle = new RectangleF();
+            object obj = new object();
+
+            // Act
+            bool result = rectangle.Equals(obj);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Same_Values()
+        {
+            // Arrange
+            var left = new RectangleF(new PointF(100, 100), new SizeF(300, 300));
+            var right = new RectangleF(new PointF(200, 200), new SizeF(400, 400));
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_True_When_Same_Values()
+        {
+            // Arrange
+            var left = new RectangleF(new PointF(100, 100), new SizeF(300, 300));
+            var right = new RectangleF(new PointF(100, 100), new SizeF(300, 300));
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Height_Property_Test_Should_Be_5568()
+        {
+            // Arrange
+            const float Expected = 5568;
+            var rectangle = new RectangleF(PointF.Empty, new SizeF(0, Expected));
+
+            // Act
+            float actual = rectangle.Height;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+
+        [Test]
+        public void Location_Property_Test()
+        {
+            // Arrange
+            var expected = new PointF(100, 400);
+
+            // Act
+            var rectangle = new RectangleF(expected, SizeF.Empty);
+
+            // Assert
+            Assert.AreEqual(expected, rectangle.Location);
+        }
+
+        [Test]
+        public void SizeF_Property_Test()
+        {
+            // Arrange
+            var expected = new SizeF(555, 222);
+
+            // Act
+            var rectangle = new RectangleF(PointF.Empty, expected);
+
+            // Assert
+            Assert.AreEqual(expected, rectangle.Size);
+        }
+
+        [Test]
+        public void Width_Property_Test_Should_Be_1025()
+        {
+            // Arrange
+            const float Expected = 1025;
+            var rectangle = new RectangleF(PointF.Empty, new SizeF(Expected, 0));
+
+            // Act
+            float actual = rectangle.Width;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+
+        [Test]
+        public void X_Property_Test_Should_Be_245()
+        {
+            // Arrange
+            const float Expected = 245;
+            var rectangle = new RectangleF(new PointF(Expected, 0), SizeF.Empty);
+
+            // Act
+            float actual = rectangle.X;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+
+        [Test]
+        public void Y_Property_Test_Should_Be_758()
+        {
+            // Arrange
+            const float Expected = 758;
+            var rectangle = new RectangleF(new PointF(0, Expected), SizeF.Empty);
+
+            // Act
+            float actual = rectangle.Y;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+    }
+}

--- a/FinalEngine.Drawing.Tests/RectangleTests.cs
+++ b/FinalEngine.Drawing.Tests/RectangleTests.cs
@@ -1,0 +1,131 @@
+﻿namespace FinalEngine.Drawing.Tests
+{
+    using NUnit.Framework;
+
+    public sealed class RectangleTests
+    {
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Rectangle()
+        {
+            // Arrange
+            var rectangle = new Rectangle();
+            object obj = new object();
+
+            // Act
+            bool result = rectangle.Equals(obj);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Same_Values()
+        {
+            // Arrange
+            var left = new Rectangle(new Point(100, 100), new Size(300, 300));
+            var right = new Rectangle(new Point(200, 200), new Size(400, 400));
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_True_When_Same_Values()
+        {
+            // Arrange
+            var left = new Rectangle(new Point(100, 100), new Size(300, 300));
+            var right = new Rectangle(new Point(100, 100), new Size(300, 300));
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Height_Property_Test_Should_Be_5568()
+        {
+            // Arrange
+            const int Expected = 5568;
+            var rectangle = new Rectangle(Point.Empty, new Size(0, Expected));
+
+            // Act
+            int actual = rectangle.Height;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+
+        [Test]
+        public void Location_Property_Test()
+        {
+            // Arrange
+            var expected = new Point(100, 400);
+
+            // Act
+            var rectangle = new Rectangle(expected, Size.Empty);
+
+            // Assert
+            Assert.AreEqual(expected, rectangle.Location);
+        }
+
+        [Test]
+        public void Size_Property_Test()
+        {
+            // Arrange
+            var expected = new Size(555, 222);
+
+            // Act
+            var rectangle = new Rectangle(Point.Empty, expected);
+
+            // Assert
+            Assert.AreEqual(expected, rectangle.Size);
+        }
+
+        [Test]
+        public void Width_Property_Test_Should_Be_1025()
+        {
+            // Arrange
+            const int Expected = 1025;
+            var rectangle = new Rectangle(Point.Empty, new Size(Expected, 0));
+
+            // Act
+            int actual = rectangle.Width;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+
+        [Test]
+        public void X_Property_Test_Should_Be_245()
+        {
+            // Arrange
+            const int Expected = 245;
+            var rectangle = new Rectangle(new Point(Expected, 0), Size.Empty);
+
+            // Act
+            int actual = rectangle.X;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+
+        [Test]
+        public void Y_Property_Test_Should_Be_758()
+        {
+            // Arrange
+            const int Expected = 758;
+            var rectangle = new Rectangle(new Point(0, Expected), Size.Empty);
+
+            // Act
+            int actual = rectangle.Y;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+    }
+}

--- a/FinalEngine.Drawing.Tests/Settings.StyleCop
+++ b/FinalEngine.Drawing.Tests/Settings.StyleCop
@@ -1,0 +1,244 @@
+<StyleCopSettings Version="105">
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="ElementsMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PartialElementsMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="EnumerationItemsMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationMustContainValidXml">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementDocumentationMustHaveSummary">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PartialElementDocumentationMustHaveSummary">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementDocumentationMustHaveSummaryText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PartialElementDocumentationMustHaveSummaryText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementDocumentationMustNotHaveDefaultSummary">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementParametersMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementParameterDocumentationMustMatchElementParameters">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementParameterDocumentationMustDeclareParameterName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementParameterDocumentationMustHaveText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementReturnValueMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementReturnValueDocumentationMustHaveText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="VoidReturnValueMustNotBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="GenericTypeParametersMustBeDocumented">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="GenericTypeParametersMustBeDocumentedPartialClass">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="GenericTypeParameterDocumentationMustMatchTypeParameters">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="GenericTypeParameterDocumentationMustDeclareParameterName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="GenericTypeParameterDocumentationMustHaveText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PropertySummaryDocumentationMustMatchAccessors">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PropertySummaryDocumentationMustOmitSetAccessorWithRestrictedAccess">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementDocumentationMustNotBeCopiedAndPasted">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="SingleLineCommentsMustNotUseDocumentationStyleSlashes">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustNotBeEmpty">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationTextMustContainWhitespace">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationMustMeetCharacterPercentage">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ConstructorSummaryDocumentationMustBeginWithStandardText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DestructorSummaryDocumentationMustBeginWithStandardText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="DocumentationHeadersMustNotContainBlankLines">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="IncludedDocumentationXPathDoesNotExist">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="IncludeNodeDoesNotContainValidFileAndPath">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="InheritDocMustBeUsedWithInheritingClass">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="ElementDocumentationMustBeSpelledCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileMustHaveHeader">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustShowCopyright">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveCopyrightText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustContainFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveValidCompanyText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchTypeName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
+      <Rules>
+        <Rule Name="PrefixLocalCallsWithThis">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PrefixCallsCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.SpacingRules">
+      <Rules>
+        <Rule Name="TabsMustNotBeUsed">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>

--- a/FinalEngine.Drawing.Tests/SizeFTests.cs
+++ b/FinalEngine.Drawing.Tests/SizeFTests.cs
@@ -1,0 +1,114 @@
+﻿namespace FinalEngine.Drawing.Tests
+{
+    using NUnit.Framework;
+
+    public sealed class SizeFTests
+    {
+        [Test]
+        public void Empty_ReadOnly_Field_Test()
+        {
+            // Arrange
+            var expected = new SizeF(0, 0);
+
+            // Act
+            SizeF actual = SizeF.Empty;
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Same_Values()
+        {
+            // Arrange
+            var left = new SizeF(100, 100);
+            var right = new SizeF(200, 200);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_SizeF()
+        {
+            // Arrange
+            var point = new SizeF(0, 0);
+            object obj = new object();
+
+            // Act
+            bool result = point.Equals(obj);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_True_When_Same_Values()
+        {
+            // Arrange
+            var left = new SizeF(156, 245);
+            var right = new SizeF(156, 245);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_False()
+        {
+            // Arrange
+            var point = new SizeF(100, 140);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_True()
+        {
+            // Arrange
+            var point = new SizeF(0, 0);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void X_Property_Test_Should_Be_45()
+        {
+            // Arrange
+            const float Expected = 45.0f;
+
+            // Act
+            var point = new SizeF(Expected, 0);
+
+            // Assert
+            Assert.AreEqual(Expected, point.Width);
+        }
+
+        [Test]
+        public void Y_Property_Test_Should_Be_68()
+        {
+            // Arrange
+            const float Expected = 68.0f;
+
+            // Act
+            var point = new SizeF(0, Expected);
+
+            // Assert
+            Assert.AreEqual(Expected, point.Height);
+        }
+    }
+}

--- a/FinalEngine.Drawing.Tests/SizeTests.cs
+++ b/FinalEngine.Drawing.Tests/SizeTests.cs
@@ -1,0 +1,114 @@
+﻿namespace FinalEngine.Drawing.Tests
+{
+    using NUnit.Framework;
+
+    public sealed class SizeTests
+    {
+        [Test]
+        public void Empty_ReadOnly_Field_Test()
+        {
+            // Arrange
+            var expected = new Size(0, 0);
+
+            // Act
+            Size actual = Size.Empty;
+
+            // Assert
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Same_Values()
+        {
+            // Arrange
+            var left = new Size(100, 100);
+            var right = new Size(200, 200);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_False_When_Not_Size()
+        {
+            // Arrange
+            var point = new Size(0, 0);
+            object obj = new object();
+
+            // Act
+            bool result = point.Equals(obj);
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void Equals_Test_Should_Be_True_When_Same_Values()
+        {
+            // Arrange
+            var left = new Size(156, 245);
+            var right = new Size(156, 245);
+
+            // Act
+            bool result = left.Equals(right);
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_False()
+        {
+            // Arrange
+            var point = new Size(100, 140);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void IsEmpty_Property_Test_Should_Be_True()
+        {
+            // Arrange
+            var point = new Size(0, 0);
+
+            // Act
+            bool result = point.IsEmpty;
+
+            // Assert
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void X_Property_Test_Should_Be_45()
+        {
+            // Arrange
+            const int Expected = 45;
+
+            // Act
+            var point = new Size(Expected, 0);
+
+            // Assert
+            Assert.AreEqual(Expected, point.Width);
+        }
+
+        [Test]
+        public void Y_Property_Test_Should_Be_68()
+        {
+            // Arrange
+            const int Expected = 68;
+
+            // Act
+            var point = new Size(0, Expected);
+
+            // Assert
+            Assert.AreEqual(Expected, point.Height);
+        }
+    }
+}

--- a/FinalEngine.Drawing/FinalEngine.Drawing.csproj
+++ b/FinalEngine.Drawing/FinalEngine.Drawing.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/FinalEngine.Drawing/FinalEngine.Drawing.csproj
+++ b/FinalEngine.Drawing/FinalEngine.Drawing.csproj
@@ -1,7 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;OPENTK</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTK.NetStandard" Version="1.0.4" />
+  </ItemGroup>
 
 </Project>

--- a/FinalEngine.Drawing/Point.cs
+++ b/FinalEngine.Drawing/Point.cs
@@ -2,25 +2,68 @@
 {
     using System;
 
+    /// <summary>
+    ///   Represents a pair of integer coordinates that defines a two dimensional point.
+    /// </summary>
+    /// <seealso cref="System.IEquatable{FinalEngine.Drawing.Point}"/>
     public struct Point : IEquatable<Point>
     {
+        /// <summary>
+        ///   Represents a <see cref="Point"/> where both coordinates have been set to zero.
+        /// </summary>
         public static readonly Point Empty = new Point(0, 0);
 
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Point"/> struct.
+        /// </summary>
+        /// <param name="x">
+        ///   Specifies the X-coordinate of this <see cref="Point"/>.
+        /// </param>
+        /// <param name="y">
+        ///   Specifies the Y-coordinate of this <see cref="Point"/>.
+        /// </param>
         public Point(int x, int y)
         {
             X = x;
             Y = y;
         }
 
+        /// <summary>
+        ///   Gets a <see cref="bool"/> indicating whether this <see cref="Point"/> is empty.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this <see cref="Point"/> is empty; otherwise, <c>false</c>.
+        /// </value>
         public bool IsEmpty
         {
             get { return Equals(Empty); }
         }
 
+        /// <summary>
+        ///   Gets or sets a <see cref="int"/> that represents the X-coordinate of this <see cref="Point"/>.
+        /// </summary>
+        /// <value>
+        ///   The X-coordinate of this <see cref="Point"/>.
+        /// </value>
         public int X { get; set; }
 
+        /// <summary>
+        ///   Gets or sets a <see cref="int"/> that represents the Y-coordinate of this <see cref="Point"/>.
+        /// </summary>
+        /// <value>
+        ///   The Y-coordinate of this <see cref="Point"/>.
+        /// </value>
         public int Y { get; set; }
 
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object"/>, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">
+        ///   The <see cref="System.Object"/> to compare with this instance.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (!(obj is Point))
@@ -31,17 +74,38 @@
             return Equals((Point)obj);
         }
 
+        /// <summary>
+        ///   Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">
+        ///   An object to compare with this object.
+        /// </param>
+        /// <returns>
+        ///   true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
         public bool Equals(Point other)
         {
             return X == other.X &&
                    Y == other.Y;
         }
 
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        ///   A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
         public override int GetHashCode()
         {
             return new { X, Y }.GetHashCode();
         }
 
+        /// <summary>
+        ///   Converts to string.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="System.String"/> that represents this instance.
+        /// </returns>
         public override string ToString()
         {
             return $"({ X }, { Y })";

--- a/FinalEngine.Drawing/Point.cs
+++ b/FinalEngine.Drawing/Point.cs
@@ -1,0 +1,50 @@
+﻿namespace FinalEngine.Drawing
+{
+    using System;
+
+    public struct Point : IEquatable<Point>
+    {
+        public static readonly Point Empty = new Point(0, 0);
+
+        public Point(int x, int y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        public bool IsEmpty
+        {
+            get { return Equals(Empty); }
+        }
+
+        public int X { get; set; }
+
+        public int Y { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Point))
+            {
+                return false;
+            }
+
+            return Equals((Point)obj);
+        }
+
+        public bool Equals(Point other)
+        {
+            return X == other.X &&
+                   Y == other.Y;
+        }
+
+        public override int GetHashCode()
+        {
+            return new { X, Y }.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"({ X }, { Y })";
+        }
+    }
+}

--- a/FinalEngine.Drawing/PointF.cs
+++ b/FinalEngine.Drawing/PointF.cs
@@ -1,0 +1,114 @@
+﻿namespace FinalEngine.Drawing
+{
+    using System;
+
+    /// <summary>
+    ///   Represents a pair of single coordinates that defines a two dimensional point.
+    /// </summary>
+    /// <seealso cref="System.IEquatable{FinalEngine.Drawing.PointF}"/>
+    public struct PointF : IEquatable<PointF>
+    {
+        /// <summary>
+        ///   Represents a <see cref="PointF"/> where both coordinates have been set to zero.
+        /// </summary>
+        public static readonly PointF Empty = new PointF(0, 0);
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="PointF"/> struct.
+        /// </summary>
+        /// <param name="x">
+        ///   Specifies the X-coordinate of this <see cref="PointF"/>.
+        /// </param>
+        /// <param name="y">
+        ///   Specifies the Y-coordinate of this <see cref="PointF"/>.
+        /// </param>
+        public PointF(float x, float y)
+        {
+            X = x;
+            Y = y;
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="bool"/> indicating whether this <see cref="PointF"/> is empty.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this <see cref="PointF"/> is empty; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsEmpty
+        {
+            get { return Equals(Empty); }
+        }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="float"/> that represents the X-coordinate of this <see cref="PointF"/>.
+        /// </summary>
+        /// <value>
+        ///   The X-coordinate of this <see cref="PointF"/>.
+        /// </value>
+        public float X { get; set; }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="float"/> that represents the Y-coordinate of this <see cref="PointF"/>.
+        /// </summary>
+        /// <value>
+        ///   The Y-coordinate of this <see cref="PointF"/>.
+        /// </value>
+        public float Y { get; set; }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object"/>, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">
+        ///   The <see cref="System.Object"/> to compare with this instance.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is PointF))
+            {
+                return false;
+            }
+
+            return Equals((PointF)obj);
+        }
+
+        /// <summary>
+        ///   Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">
+        ///   An object to compare with this object.
+        /// </param>
+        /// <returns>
+        ///   true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(PointF other)
+        {
+            return X == other.X &&
+                   Y == other.Y;
+        }
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        ///   A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return new { X, Y }.GetHashCode();
+        }
+
+        /// <summary>
+        ///   Converts to string.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"({ X }, { Y })";
+        }
+    }
+}

--- a/FinalEngine.Drawing/PointF.cs
+++ b/FinalEngine.Drawing/PointF.cs
@@ -3,7 +3,7 @@
     using System;
 
     /// <summary>
-    ///   Represents a pair of single coordinates that defines a two dimensional point.
+    ///   Represents a pair of single precision floating-point coordinates that defines a two dimensional point.
     /// </summary>
     /// <seealso cref="System.IEquatable{FinalEngine.Drawing.PointF}"/>
     public struct PointF : IEquatable<PointF>

--- a/FinalEngine.Drawing/Rectangle.cs
+++ b/FinalEngine.Drawing/Rectangle.cs
@@ -2,48 +2,121 @@
 {
     using System;
 
+    /// <summary>
+    ///   Represents a rectangular region (represented with integers) on a two dimensional plane.
+    /// </summary>
+    /// <seealso cref="System.IEquatable{FinalEngine.Drawing.Rectangle}"/>
     public struct Rectangle : IEquatable<Rectangle>
     {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Rectangle"/> struct.
+        /// </summary>
+        /// <param name="location">
+        ///   Specifies the location of this <see cref="Rectangle"/>.
+        /// </param>
+        /// <param name="size">
+        ///   Specifies the size of this <see cref="Rectangle"/>.
+        /// </param>
         public Rectangle(Point location, Size size)
         {
             Location = location;
             Size = size;
         }
 
+        /// <summary>
+        ///   Gets a <see cref="int"/> that represents the height of this <see cref="Rectangle"/>.
+        /// </summary>
+        /// <value>
+        ///   The height of this <see cref="Rectangle"/>.
+        /// </value>
         public int Height
         {
             get { return Size.Height; }
         }
 
+        /// <summary>
+        ///   Gets a <see cref="bool"/> indicating whether this <see cref="Rectangle"/> is empty.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this <see cref="Rectangle"/> is empty; otherwise, <c>false</c>.
+        /// </value>
         public bool IsEmpty
         {
             get { return Location.IsEmpty && Size.IsEmpty; }
         }
 
+        /// <summary>
+        ///   Gets or sets a <see cref="Point"/> that represents the location of this <see cref="Rectangle"/>.
+        /// </summary>
+        /// <value>
+        ///   The location of this <see cref="Rectangle"/>.
+        /// </value>
         public Point Location { get; set; }
 
+        /// <summary>
+        ///   Gets or sets a <see cref="Size"/> that represents the size of this <see cref="Rectangle"/>.
+        /// </summary>
+        /// <value>
+        ///   The size of this <see cref="Rectangle"/>.
+        /// </value>
         public Size Size { get; set; }
 
+        /// <summary>
+        ///   Gets a <see cref="int"/> that represents the width of this <see cref="Rectangle"/>.
+        /// </summary>
+        /// <value>
+        ///   The width of this <see cref="Rectangle"/>.
+        /// </value>
         public int Width
         {
             get { return Size.Width; }
         }
 
+        /// <summary>
+        ///   Gets a <see cref="int"/> that represents the X-coordinate of this <see cref="Rectangle"/>.
+        /// </summary>
+        /// <value>
+        ///   The X-coordinate of this <see cref="Rectangle"/>.
+        /// </value>
         public int X
         {
             get { return Location.X; }
         }
 
+        /// <summary>
+        ///   Gets a <see cref="int"/> that represents the Y-coordinate of this <see cref="Rectangle"/>.
+        /// </summary>
+        /// <value>
+        ///   The Y-coordinate of this <see cref="Rectangle"/>.
+        /// </value>
         public int Y
         {
             get { return Location.Y; }
         }
 
+        /// <summary>
+        ///   Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">
+        ///   An object to compare with this object.
+        /// </param>
+        /// <returns>
+        ///   true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
         public bool Equals(Rectangle other)
         {
             return Location.Equals(other.Location) && Size.Equals(other.Size);
         }
 
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object"/>, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">
+        ///   The <see cref="System.Object"/> to compare with this instance.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
         public override bool Equals(object obj)
         {
             if (!(obj is Rectangle))
@@ -54,11 +127,23 @@
             return Equals((Rectangle)obj);
         }
 
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        ///   A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
         public override int GetHashCode()
         {
             return new { Location, Size }.GetHashCode();
         }
 
+        /// <summary>
+        ///   Converts to string.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="System.String"/> that represents this instance.
+        /// </returns>
         public override string ToString()
         {
             return $"({ Location }, { Size }";

--- a/FinalEngine.Drawing/Rectangle.cs
+++ b/FinalEngine.Drawing/Rectangle.cs
@@ -1,0 +1,67 @@
+﻿namespace FinalEngine.Drawing
+{
+    using System;
+
+    public struct Rectangle : IEquatable<Rectangle>
+    {
+        public Rectangle(Point location, Size size)
+        {
+            Location = location;
+            Size = size;
+        }
+
+        public int Height
+        {
+            get { return Size.Height; }
+        }
+
+        public bool IsEmpty
+        {
+            get { return Location.IsEmpty && Size.IsEmpty; }
+        }
+
+        public Point Location { get; set; }
+
+        public Size Size { get; set; }
+
+        public int Width
+        {
+            get { return Size.Width; }
+        }
+
+        public int X
+        {
+            get { return Location.X; }
+        }
+
+        public int Y
+        {
+            get { return Location.Y; }
+        }
+
+        public bool Equals(Rectangle other)
+        {
+            return Location.Equals(other.Location) && Size.Equals(other.Size);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Rectangle))
+            {
+                return false;
+            }
+
+            return Equals((Rectangle)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return new { Location, Size }.GetHashCode();
+        }
+
+        public override string ToString()
+        {
+            return $"({ Location }, { Size }";
+        }
+    }
+}

--- a/FinalEngine.Drawing/RectangleF.cs
+++ b/FinalEngine.Drawing/RectangleF.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace FinalEngine.Drawing
+{
+    class RectangleF
+    {
+    }
+}

--- a/FinalEngine.Drawing/RectangleF.cs
+++ b/FinalEngine.Drawing/RectangleF.cs
@@ -1,10 +1,152 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace FinalEngine.Drawing
+﻿namespace FinalEngine.Drawing
 {
-    class RectangleF
+    using System;
+
+    /// <summary>
+    ///   Represents a rectangular region (represented with single precision floating-points) on a two dimensional plane.
+    /// </summary>
+    /// <seealso cref="System.IEquatable{FinalEngine.Drawing.RectangleF}"/>
+    public struct RectangleF : IEquatable<RectangleF>
     {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="RectangleF"/> struct.
+        /// </summary>
+        /// <param name="location">
+        ///   Specifies the location of this <see cref="RectangleF"/>.
+        /// </param>
+        /// <param name="size">
+        ///   Specifies the size of this <see cref="RectangleF"/>.
+        /// </param>
+        public RectangleF(PointF location, SizeF size)
+        {
+            Location = location;
+            Size = size;
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="float"/> that represents the height of this <see cref="RectangleF"/>.
+        /// </summary>
+        /// <value>
+        ///   The height of this <see cref="RectangleF"/>.
+        /// </value>
+        public float Height
+        {
+            get { return Size.Height; }
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="bool"/> indicating whether this <see cref="RectangleF"/> is empty.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this <see cref="RectangleF"/> is empty; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsEmpty
+        {
+            get { return Location.IsEmpty && Size.IsEmpty; }
+        }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="PointF"/> that represents the location of this <see cref="RectangleF"/>.
+        /// </summary>
+        /// <value>
+        ///   The location of this <see cref="RectangleF"/>.
+        /// </value>
+        public PointF Location { get; set; }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="Size"/> that represents the size of this <see cref="RectangleF"/>.
+        /// </summary>
+        /// <value>
+        ///   The size of this <see cref="RectangleF"/>.
+        /// </value>
+        public SizeF Size { get; set; }
+
+        /// <summary>
+        ///   Gets a <see cref="float"/> that represents the width of this <see cref="RectangleF"/>.
+        /// </summary>
+        /// <value>
+        ///   The width of this <see cref="RectangleF"/>.
+        /// </value>
+        public float Width
+        {
+            get { return Size.Width; }
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="float"/> that represents the X-coordinate of this <see cref="RectangleF"/>.
+        /// </summary>
+        /// <value>
+        ///   The X-coordinate of this <see cref="RectangleF"/>.
+        /// </value>
+        public float X
+        {
+            get { return Location.X; }
+        }
+
+        /// <summary>
+        ///   Gets a <see cref="float"/> that represents the Y-coordinate of this <see cref="RectangleF"/>.
+        /// </summary>
+        /// <value>
+        ///   The Y-coordinate of this <see cref="RectangleF"/>.
+        /// </value>
+        public float Y
+        {
+            get { return Location.Y; }
+        }
+
+        /// <summary>
+        ///   Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">
+        ///   An object to compare with this object.
+        /// </param>
+        /// <returns>
+        ///   true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(RectangleF other)
+        {
+            return Location.Equals(other.Location) && Size.Equals(other.Size);
+        }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object"/>, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">
+        ///   The <see cref="System.Object"/> to compare with this instance.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is RectangleF))
+            {
+                return false;
+            }
+
+            return Equals((RectangleF)obj);
+        }
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        ///   A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return new { Location, Size }.GetHashCode();
+        }
+
+        /// <summary>
+        ///   Converts to string.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"({ Location }, { Size }";
+        }
     }
 }

--- a/FinalEngine.Drawing/Settings.StyleCop
+++ b/FinalEngine.Drawing/Settings.StyleCop
@@ -37,6 +37,11 @@
             <BooleanProperty Name="Enabled">False</BooleanProperty>
           </RuleSettings>
         </Rule>
+        <Rule Name="PropertySummaryDocumentationMustMatchAccessors">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
       </Rules>
       <AnalyzerSettings />
     </Analyzer>

--- a/FinalEngine.Drawing/Settings.StyleCop
+++ b/FinalEngine.Drawing/Settings.StyleCop
@@ -1,0 +1,69 @@
+<StyleCopSettings Version="105">
+  <Analyzers>
+    <Analyzer AnalyzerId="StyleCop.CSharp.DocumentationRules">
+      <Rules>
+        <Rule Name="FileMustHaveHeader">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustShowCopyright">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveCopyrightText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustContainFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchFileName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderMustHaveValidCompanyText">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="FileHeaderFileNameDocumentationMustMatchTypeName">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.ReadabilityRules">
+      <Rules>
+        <Rule Name="PrefixLocalCallsWithThis">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+        <Rule Name="PrefixCallsCorrectly">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+    <Analyzer AnalyzerId="StyleCop.CSharp.SpacingRules">
+      <Rules>
+        <Rule Name="TabsMustNotBeUsed">
+          <RuleSettings>
+            <BooleanProperty Name="Enabled">False</BooleanProperty>
+          </RuleSettings>
+        </Rule>
+      </Rules>
+      <AnalyzerSettings />
+    </Analyzer>
+  </Analyzers>
+</StyleCopSettings>

--- a/FinalEngine.Drawing/Size.cs
+++ b/FinalEngine.Drawing/Size.cs
@@ -1,0 +1,114 @@
+﻿namespace FinalEngine.Drawing
+{
+    using System;
+
+    /// <summary>
+    ///   Represents a pair of integers that defines a two dimensional space.
+    /// </summary>
+    /// <seealso cref="System.IEquatable{FinalEngine.Drawing.Size}"/>
+    public struct Size : IEquatable<Size>
+    {
+        /// <summary>
+        ///   Represents a <see cref="Size"/> where both dimensions have been set to zero.
+        /// </summary>
+        public static readonly Size Empty = new Size(0, 0);
+
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="Size"/> struct.
+        /// </summary>
+        /// <param name="width">
+        ///   Specifies the width of this <see cref="Size"/>.
+        /// </param>
+        /// <param name="height">
+        ///   Specifies the height of this <see cref="Size"/>.
+        /// </param>
+        public Size(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="int"/> that represents the height of this <see cref="Size"/>.
+        /// </summary>
+        /// <value>
+        ///   The Y-coordinate of this <see cref="Size"/>.
+        /// </value>
+        public int Height { get; set; }
+
+        /// <summary>
+        ///   Gets a <see cref="bool"/> indicating whether this <see cref="Size"/> is empty.
+        /// </summary>
+        /// <value>
+        ///   <c>true</c> if this <see cref="Size"/> is empty; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsEmpty
+        {
+            get { return Equals(Empty); }
+        }
+
+        /// <summary>
+        ///   Gets or sets a <see cref="int"/> that represents the width of this <see cref="Size"/>.
+        /// </summary>
+        /// <value>
+        ///   The X-coordinate of this <see cref="Size"/>.
+        /// </value>
+        public int Width { get; set; }
+
+        /// <summary>
+        ///   Determines whether the specified <see cref="System.Object"/>, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">
+        ///   The <see cref="System.Object"/> to compare with this instance.
+        /// </param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is Size))
+            {
+                return false;
+            }
+
+            return Equals((Size)obj);
+        }
+
+        /// <summary>
+        ///   Indicates whether the current object is equal to another object of the same type.
+        /// </summary>
+        /// <param name="other">
+        ///   An object to compare with this object.
+        /// </param>
+        /// <returns>
+        ///   true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
+        /// </returns>
+        public bool Equals(Size other)
+        {
+            return Width == other.Width &&
+                   Height == other.Height;
+        }
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        ///   A hash code for this instance, suitable for use in hashing algorithms and data structures like a hash table.
+        /// </returns>
+        public override int GetHashCode()
+        {
+            return new { Width, Height }.GetHashCode();
+        }
+
+        /// <summary>
+        ///   Converts to string.
+        /// </summary>
+        /// <returns>
+        ///   A <see cref="System.String"/> that represents this instance.
+        /// </returns>
+        public override string ToString()
+        {
+            return $"({ Width }, { Height })";
+        }
+    }
+}

--- a/FinalEngine.Drawing/SizeF.cs
+++ b/FinalEngine.Drawing/SizeF.cs
@@ -3,44 +3,44 @@
     using System;
 
     /// <summary>
-    ///   Represents a pair of integers that defines a two dimensional space.
+    ///   Represents a pair of single precision floating-point values that defines a two dimensional space.
     /// </summary>
-    /// <seealso cref="System.IEquatable{FinalEngine.Drawing.Size}"/>
-    public struct Size : IEquatable<Size>
+    /// <seealso cref="System.IEquatable{FinalEngine.Drawing.SizeF}"/>
+    public struct SizeF : IEquatable<SizeF>
     {
         /// <summary>
-        ///   Represents a <see cref="Size"/> where the dimensions have been set to zero.
+        ///   Represents a <see cref="SizeF"/> where the dimensions have been set to zero.
         /// </summary>
-        public static readonly Size Empty = new Size(0, 0);
+        public static readonly SizeF Empty = new SizeF(0, 0);
 
         /// <summary>
-        ///   Initializes a new instance of the <see cref="Size"/> struct.
+        ///   Initializes a new instance of the <see cref="SizeF"/> struct.
         /// </summary>
         /// <param name="width">
-        ///   Specifies the width of this <see cref="Size"/>.
+        ///   Specifies the width of this <see cref="SizeF"/>.
         /// </param>
         /// <param name="height">
-        ///   Specifies the height of this <see cref="Size"/>.
+        ///   Specifies the height of this <see cref="SizeF"/>.
         /// </param>
-        public Size(int width, int height)
+        public SizeF(float width, float height)
         {
             Width = width;
             Height = height;
         }
 
         /// <summary>
-        ///   Gets or sets a <see cref="int"/> that represents the height of this <see cref="Size"/>.
+        ///   Gets or sets a <see cref="float"/> that represents the height of this <see cref="SizeF"/>.
         /// </summary>
         /// <value>
-        ///   The height of this <see cref="Size"/>.
+        ///   The height of this <see cref="SizeF"/>.
         /// </value>
-        public int Height { get; set; }
+        public float Height { get; set; }
 
         /// <summary>
-        ///   Gets a <see cref="bool"/> indicating whether this <see cref="Size"/> is empty.
+        ///   Gets a <see cref="bool"/> indicating whether this <see cref="SizeF"/> is empty.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if this <see cref="Size"/> is empty; otherwise, <c>false</c>.
+        ///   <c>true</c> if this <see cref="SizeF"/> is empty; otherwise, <c>false</c>.
         /// </value>
         public bool IsEmpty
         {
@@ -48,12 +48,12 @@
         }
 
         /// <summary>
-        ///   Gets or sets a <see cref="int"/> that represents the width of this <see cref="Size"/>.
+        ///   Gets or sets a <see cref="float"/> that represents the width of this <see cref="SizeF"/>.
         /// </summary>
         /// <value>
-        ///   The width of this <see cref="Size"/>.
+        ///   The width of this <see cref="SizeF"/>.
         /// </value>
-        public int Width { get; set; }
+        public float Width { get; set; }
 
         /// <summary>
         ///   Determines whether the specified <see cref="System.Object"/>, is equal to this instance.
@@ -66,12 +66,12 @@
         /// </returns>
         public override bool Equals(object obj)
         {
-            if (!(obj is Size))
+            if (!(obj is SizeF))
             {
                 return false;
             }
 
-            return Equals((Size)obj);
+            return Equals((SizeF)obj);
         }
 
         /// <summary>
@@ -83,7 +83,7 @@
         /// <returns>
         ///   true if the current object is equal to the <paramref name="other">other</paramref> parameter; otherwise, false.
         /// </returns>
-        public bool Equals(Size other)
+        public bool Equals(SizeF other)
         {
             return Width == other.Width &&
                    Height == other.Height;

--- a/FinalEngine.Maths/Vector2.cs
+++ b/FinalEngine.Maths/Vector2.cs
@@ -9,7 +9,7 @@
     public struct Vector2 : IEquatable<Vector2>
     {
         /// <summary>
-        ///   Represents a <see cref="Vector2"/> that point down (0, -1).
+        ///   Represents a <see cref="Vector2"/> that points down (0, -1).
         /// </summary>
         public static Vector2 Down = new Vector2(0, -1);
 

--- a/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
+++ b/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
@@ -12,4 +12,11 @@
     <ProjectReference Include="..\FinalEngine.Platform\FinalEngine.Platform.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="OpenTKExtensions.cs">
+      <ExcludeFromSourceAnalysis>True</ExcludeFromSourceAnalysis>
+      <ExcludeFromStyleCop>True</ExcludeFromStyleCop>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/FinalEngine.Platform.Desktop/OpenTKDisplay.cs
+++ b/FinalEngine.Platform.Desktop/OpenTKDisplay.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.ComponentModel;
-    using System.Drawing;
+    using FinalEngine.Drawing;
 
     /// <summary>
     ///   Provides an <see cref="OpenTK.NativeWindow"/> implementation of an <see cref="IDisplay"/> and <see cref="IEventsProcessor"/>.
@@ -45,7 +45,7 @@
         /// </value>
         Rectangle IDisplay.ClientRectangle
         {
-            get { return new Rectangle(ClientRectangle.X, ClientRectangle.Y, ClientRectangle.Width, ClientRectangle.Height); }
+            get { return ClientRectangle.ToRectangle(); }
         }
 
         /// <summary>
@@ -56,49 +56,33 @@
         /// </value>
         Size IDisplay.ClientSize
         {
-            get { return new Size(ClientSize.Width, ClientSize.Height); }
+            get { return ClientSize.ToSize(); }
         }
 
         /// <summary>
-        ///   Gets a <see cref="bool"/> indicating whether this <see cref="OpenTKDisplay"/> is closing.
+        ///   Gets a <see cref="T:System.Boolean"/> indicating whether this <see cref="OpenTKDisplay"/> is closing.
         /// </summary>
         /// <value>
-        ///   <c>true</c> if this <see cref="OpenTKDisplay"/> is closing; otherwise, <c>false</c>.
+        ///   <c>true</c> if this <see cref="OpenTK"/> is closing; otherwise, <c>false</c>.
         /// </value>
         public bool IsClosing { get; private set; }
 
         /// <summary>
-        ///   Gets or sets a <see cref="Point"/> structure that contains the location of this <see cref="OpenTKDisplay"/> on the desktop.
+        ///   Gets or sets a <see cref="Point"/> structure that contains the location of this window on the desktop.
         /// </summary>
         Point IDisplay.Location
         {
-            get
-            {
-                return new Point(X, Y);
-            }
-
-            set
-            {
-                X = value.X;
-                Y = value.Y;
-            }
+            get { return Location.ToPoint(); }
+            set { Location = value.ToTKPoint(); }
         }
 
         /// <summary>
-        ///   Gets or sets a <see cref="Size"/> structure that contains the external size of this <see cref="OpenTKDisplay"/>.
+        ///   Gets or sets a <see cref="Size"/> structure that contains the external size of this window.
         /// </summary>
         Size IDisplay.Size
         {
-            get
-            {
-                return new Size(Width, Height);
-            }
-
-            set
-            {
-                Width = value.Width;
-                Height = value.Height;
-            }
+            get { return Size.ToSize(); }
+            set { Size = value.ToTKSize(); }
         }
 
         /// <summary>

--- a/FinalEngine.Platform.Desktop/OpenTKExtensions.cs
+++ b/FinalEngine.Platform.Desktop/OpenTKExtensions.cs
@@ -1,0 +1,73 @@
+﻿namespace FinalEngine.Platform.Desktop
+{
+    using FinalEngine.Drawing;
+    using TKPoint = OpenTK.Point;
+    using TKPointF = OpenTK.PointF;
+    using TKRectangle = OpenTK.Rectangle;
+    using TKRectangleF = OpenTK.RectangleF;
+    using TKSize = OpenTK.Size;
+    using TKSizeF = OpenTK.SizeF;
+
+    public static class OpenTKExtensions
+    {
+        public static Point ToPoint(this TKPoint point)
+        {
+            return new Point(point.X, point.Y);
+        }
+
+        public static PointF ToPointF(this TKPointF point)
+        {
+            return new PointF(point.X, point.Y);
+        }
+
+        public static Rectangle ToRectangle(this TKRectangle rectangle)
+        {
+            return new Rectangle(rectangle.Location.ToPoint(), rectangle.Size.ToSize());
+        }
+
+        public static RectangleF ToRectangleF(this TKRectangleF rectangle)
+        {
+            return new RectangleF(rectangle.Location.ToPointF(), rectangle.Size.ToSizeF());
+        }
+
+        public static Size ToSize(this TKSize size)
+        {
+            return new Size(size.Width, size.Height);
+        }
+
+        public static SizeF ToSizeF(this TKSizeF size)
+        {
+            return new SizeF(size.Width, size.Height);
+        }
+
+        public static TKPoint ToTKPoint(this Point point)
+        {
+            return new TKPoint(point.X, point.Y);
+        }
+
+        public static TKPointF ToTKPointF(this PointF point)
+        {
+            return new TKPointF(point.X, point.Y);
+        }
+
+        public static TKRectangle ToTKRectangle(this Rectangle rectangle)
+        {
+            return new TKRectangle(rectangle.Location.ToTKPoint(), rectangle.Size.ToTKSize());
+        }
+
+        public static TKRectangleF ToTKRectangleF(this RectangleF rectangle)
+        {
+            return new TKRectangleF(rectangle.Location.ToTKPointF(), rectangle.Size.ToTKSizeF());
+        }
+
+        public static TKSize ToTKSize(this Size size)
+        {
+            return new TKSize(size.Width, size.Height);
+        }
+
+        public static TKSizeF ToTKSizeF(this SizeF size)
+        {
+            return new TKSizeF(size.Width, size.Height);
+        }
+    }
+}

--- a/FinalEngine.Platform/FinalEngine.Platform.csproj
+++ b/FinalEngine.Platform/FinalEngine.Platform.csproj
@@ -1,7 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Drawing\FinalEngine.Drawing.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/FinalEngine.Platform/IDisplay.cs
+++ b/FinalEngine.Platform/IDisplay.cs
@@ -1,7 +1,7 @@
 ﻿namespace FinalEngine.Platform
 {
     using System;
-    using System.Drawing;
+    using FinalEngine.Drawing;
 
     /// <summary>
     ///   Defines an interface that represents a display or window.

--- a/FinalEngine.sln
+++ b/FinalEngine.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Sandbox.Desktop
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Drawing", "FinalEngine.Drawing\FinalEngine.Drawing.csproj", "{3B85587D-8873-4F6F-87FF-A7881F8B655A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Drawing.Tests", "FinalEngine.Drawing.Tests\FinalEngine.Drawing.Tests.csproj", "{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -133,6 +135,18 @@ Global
 		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|x64.Build.0 = Release|Any CPU
 		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|x86.ActiveCfg = Release|Any CPU
 		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|x86.Build.0 = Release|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Debug|x64.Build.0 = Debug|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Debug|x86.Build.0 = Debug|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Release|x64.ActiveCfg = Release|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Release|x64.Build.0 = Release|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Release|x86.ActiveCfg = Release|Any CPU
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -147,6 +161,7 @@ Global
 		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7} = {F352E63D-4DFC-488A-A41E-A066C4994AA8}
 		{3A71EEE9-7839-44BF-A151-924E0E0623A0} = {A6D0464A-3797-428D-8E93-91EF7779E761}
 		{3B85587D-8873-4F6F-87FF-A7881F8B655A} = {D4445AC7-89F7-4DDE-A59C-089BE8360C23}
+		{4AF91C5C-2B40-4FA1-82F8-DBDC08AB9F14} = {630A1D15-42F7-444E-A7EC-96271CD4DE8C}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A278B383-0D14-41B3-A71C-4505E1D503DF}

--- a/FinalEngine.sln
+++ b/FinalEngine.sln
@@ -19,11 +19,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Logging", "Fina
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Logging.Tests", "FinalEngine.Logging.Tests\FinalEngine.Logging.Tests.csproj", "{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Platform.Desktop", "FinalEngine.Platform.Desktop\FinalEngine.Platform.Desktop.csproj", "{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Platform.Desktop", "FinalEngine.Platform.Desktop\FinalEngine.Platform.Desktop.csproj", "{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sandbox", "Sandbox", "{A6D0464A-3797-428D-8E93-91EF7779E761}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Sandbox.Desktop", "FinalEngine.Sandbox.Desktop\FinalEngine.Sandbox.Desktop.csproj", "{3A71EEE9-7839-44BF-A151-924E0E0623A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Sandbox.Desktop", "FinalEngine.Sandbox.Desktop\FinalEngine.Sandbox.Desktop.csproj", "{3A71EEE9-7839-44BF-A151-924E0E0623A0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Drawing", "FinalEngine.Drawing\FinalEngine.Drawing.csproj", "{3B85587D-8873-4F6F-87FF-A7881F8B655A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -119,6 +121,18 @@ Global
 		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|x64.Build.0 = Release|Any CPU
 		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|x86.ActiveCfg = Release|Any CPU
 		{3A71EEE9-7839-44BF-A151-924E0E0623A0}.Release|x86.Build.0 = Release|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Debug|x64.Build.0 = Debug|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Debug|x86.Build.0 = Debug|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|x64.ActiveCfg = Release|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|x64.Build.0 = Release|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|x86.ActiveCfg = Release|Any CPU
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -132,6 +146,7 @@ Global
 		{38DD8C5D-FB8A-4BC8-8AF5-4FFBAF2B7554} = {630A1D15-42F7-444E-A7EC-96271CD4DE8C}
 		{9B703BFF-0A6E-4C4A-91C1-A3DDBEFC49B7} = {F352E63D-4DFC-488A-A41E-A066C4994AA8}
 		{3A71EEE9-7839-44BF-A151-924E0E0623A0} = {A6D0464A-3797-428D-8E93-91EF7779E761}
+		{3B85587D-8873-4F6F-87FF-A7881F8B655A} = {D4445AC7-89F7-4DDE-A59C-089BE8360C23}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A278B383-0D14-41B3-A71C-4505E1D503DF}


### PR DESCRIPTION
# Description

I've created a very simple drawing primitives library so that we can close #17 and _hopefully_ finally get started on handling input and rendering for FE. The following structures have been added:

- Point
- PointF
- Size
- SizeF
- Rectangle
- RectangleF

Also, an `OpenTKExtensions` class has been added in the `FinalEngine.Platform.Desktop` project to allow easy conversion between the above types and OpenTK's versions. For example, you can convert a `Point` and an `OpenTK.Point` by typing `var point = new Point(0, 0).ToTKPoint()`.

Fixes #17 

## Dependencies

This PR doesn't introduce any dependencies at all as it only introduces core functionality, which should **never** introduce any external dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I have provided unit tests for testable code exclduing any `GetHashCode()` and `ToString()` methods. All tests pass locally on my machine. The unit tests can be found under the new project `FinalEngine.Drawing.Tests`.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ
* Toolchain: VS Community 2019

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
