### PR TITLE
Fix Direct3D11Rasterizer issue where not disposing of resource

### DIFF
--- a/FinalEngine.Rendering.Direct3D11/Direct3D11Rasterizer.cs
+++ b/FinalEngine.Rendering.Direct3D11/Direct3D11Rasterizer.cs
@@ -55,7 +55,7 @@
 
             deviceContext.RSSetState(state);
 
-            state.Release();
+            state.Dispose();
         }
 
         /// <summary>


### PR DESCRIPTION
It turns out that `ComObject` (judging by the interface) is calling the `Release()` function within it's `Dispose()` function. As such, it's best to fix it up now rather than later.