### PR TITLE
Fixed State Descriptions to use nullable types

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: microsoft/dotnet:3.1-sdk
+      - image: microsoft/dotnet:2.1-sdk
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: microsoft/dotnet:2.1-sdk
+      - image: microsoft/dotnet:3.1-sdk
     steps:
       - checkout
       - run:

--- a/FinalEngine.Rendering.Tests/FinalEngine.Rendering.Tests.csproj
+++ b/FinalEngine.Rendering.Tests/FinalEngine.Rendering.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/FinalEngine.Rendering.Tests/FinalEngine.Rendering.Tests.csproj
+++ b/FinalEngine.Rendering.Tests/FinalEngine.Rendering.Tests.csproj
@@ -6,6 +6,10 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;SA0001</NoWarn>
+  </PropertyGroup>
+
   <ItemGroup>
     <AdditionalFiles Include="..\Styling\StyleCop\Tests\stylecop.json" Link="stylecop.json" />
     <AdditionalFiles Include="RasterStateDescriptionTests.cs" />

--- a/FinalEngine.Rendering.Tests/FinalEngine.Rendering.Tests.csproj
+++ b/FinalEngine.Rendering.Tests/FinalEngine.Rendering.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\Styling\StyleCop\Tests\stylecop.json" Link="stylecop.json" />
+    <AdditionalFiles Include="RasterStateDescriptionTests.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Rendering\FinalEngine.Rendering.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/FinalEngine.Rendering.Tests/RasterStateDescriptionTests.cs
+++ b/FinalEngine.Rendering.Tests/RasterStateDescriptionTests.cs
@@ -42,5 +42,122 @@ namespace FinalEngine.Rendering.Tests
             // Assert
             Assert.IsFalse(state.CullEnabled);
         }
+
+        [Test]
+        public void FaceCullMode_Test_Should_Return_Back_When_Default()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            FaceCullMode actual = state.FaceCullMode;
+
+            // Assert
+            Assert.AreEqual(FaceCullMode.Back, actual);
+        }
+
+        [Test]
+        public void FaceCullMode_Test_Should_Return_Front_When_Property_Set_To_Front()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.FaceCullMode = FaceCullMode.Front;
+
+            // Assert
+            Assert.AreEqual(FaceCullMode.Front, state.FaceCullMode);
+        }
+
+        [Test]
+        public void FaceCullMode_Test_Should_Return_Back_When_Property_Set_To_Back()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.FaceCullMode = FaceCullMode.Back;
+
+            // Assert
+            Assert.AreEqual(FaceCullMode.Back, state.FaceCullMode);
+        }
+
+        [Test]
+        public void FillMode_Test_Should_Return_Solid_When_Default()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            RasterMode actual = state.FillMode;
+
+            // Assert
+            Assert.AreEqual(RasterMode.Solid, actual);
+        }
+
+        [Test]
+        public void FillMode_Test_Should_Return_Wireframe_When_Property_Set_To_Wireframe()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.FillMode = RasterMode.Wireframe;
+
+            // Assert
+            Assert.AreEqual(RasterMode.Wireframe, state.FillMode);
+        }
+
+        [Test]
+        public void FillMode_Test_Should_Return_Solid_When_Property_Set_To_Solid()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.FillMode = RasterMode.Solid;
+
+            // Assert
+            Assert.AreEqual(RasterMode.Solid, state.FillMode);
+        }
+
+        [Test]
+        public void WindingDirection_Test_Should_Return_CounterClockwise_When_Default()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            WindingDirection actual = state.WindingDirection;
+
+            // Assert
+            Assert.AreEqual(WindingDirection.CounterClockwise, actual);
+        }
+
+        [Test]
+        public void WindingDirection_Test_Should_Return_CounterClockwise_When_Property_Set_To_CounterClockwise()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.WindingDirection = WindingDirection.CounterClockwise;
+
+            // Assert
+            Assert.AreEqual(WindingDirection.CounterClockwise, state.WindingDirection);
+        }
+
+        [Test]
+        public void WindingDirection_Test_Should_Return_Clockwise_When_Property_Set_To_Clockwise()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.WindingDirection = WindingDirection.Clockwise;
+
+            // Assert
+            Assert.AreEqual(WindingDirection.Clockwise, state.WindingDirection);
+        }
     }
 }

--- a/FinalEngine.Rendering.Tests/RasterStateDescriptionTests.cs
+++ b/FinalEngine.Rendering.Tests/RasterStateDescriptionTests.cs
@@ -1,0 +1,46 @@
+namespace FinalEngine.Rendering.Tests
+{
+    using NUnit.Framework;
+
+    public class RasterStateDescriptionTests
+    {
+        [Test]
+        public void CullEnabled_Test_Should_Equal_False_When_Default()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            bool actual = state.CullEnabled;
+
+            // Assert
+            Assert.IsFalse(actual);
+        }
+
+        [Test]
+        public void CullEnabled_Test_Should_Equal_True_When_Property_Set_To_True()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.CullEnabled = true;
+
+            // Assert
+            Assert.IsTrue(state.CullEnabled);
+        }
+
+        [Test]
+        public void CullEnabled_Test_Should_Equal_False_When_Property_Set_To_False()
+        {
+            // Arrange
+            RasterStateDescription state = default;
+
+            // Act
+            state.CullEnabled = false;
+
+            // Assert
+            Assert.IsFalse(state.CullEnabled);
+        }
+    }
+}

--- a/FinalEngine.Rendering.Tests/RasterStateDescriptionTests.cs
+++ b/FinalEngine.Rendering.Tests/RasterStateDescriptionTests.cs
@@ -1,3 +1,7 @@
+// <copyright file="RasterStateDescriptionTests.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
 namespace FinalEngine.Rendering.Tests
 {
     using NUnit.Framework;

--- a/FinalEngine.Rendering/FinalEngine.Rendering.csproj
+++ b/FinalEngine.Rendering/FinalEngine.Rendering.csproj
@@ -1,22 +1,23 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>8.0</LangVersion>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;SA0001</NoWarn>
-  </PropertyGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<NoWarn>1701;1702;SA0001</NoWarn>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
-  </ItemGroup>
+	<ItemGroup>
+		<AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
-
+	<ItemGroup>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
 </Project>

--- a/FinalEngine.Rendering/IRasterizer.cs
+++ b/FinalEngine.Rendering/IRasterizer.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="IRasterizer.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.Rendering

--- a/FinalEngine.Rendering/RasterStateDescription.cs
+++ b/FinalEngine.Rendering/RasterStateDescription.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright file="RasterStateDescription.cs" company="Software Antics">
-// Copyright (c) Software Antics. All rights reserved.
+//     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.Rendering
@@ -58,24 +58,24 @@ namespace FinalEngine.Rendering
     public struct RasterStateDescription
     {
         /// <summary>
-        ///   Gets a <see cref="RasterStateDescription"/> that represents the default state of a rasterizer.
+        ///   Indicates whether culling is enabled for the rasterizer.
         /// </summary>
-        /// <value>
-        ///   The default state of a rasterizer.
-        /// </value>
-        public static RasterStateDescription Default
-        {
-            get
-            {
-                return new RasterStateDescription()
-                {
-                    CullEnabled = false,
-                    FaceCullMode = FaceCullMode.Back,
-                    FillMode = RasterMode.Solid,
-                    WindingDirection = WindingDirection.CounterClockwise,
-                };
-            }
-        }
+        private bool? cullEnabled;
+
+        /// <summary>
+        ///   Represents which primitives will not be drawn by the rasterizer.
+        /// </summary>
+        private FaceCullMode? faceCullMode;
+
+        /// <summary>
+        ///   Represents how the rasterizer will draw polygons.
+        /// </summary>
+        private RasterMode? fillMode;
+
+        /// <summary>
+        ///   Reprsents the front face of a primitive (the winding draw-order).
+        /// </summary>
+        private WindingDirection? windingDirection;
 
         /// <summary>
         ///   Gets or sets a value indicating whether culling is enabled for the rasterizer.
@@ -83,7 +83,11 @@ namespace FinalEngine.Rendering
         /// <value>
         ///   <c>true</c> if culling is enabled for the rasterizer; otherwise, <c>false</c>.
         /// </value>
-        public bool CullEnabled { get; set; }
+        public bool CullEnabled
+        {
+            get { return this.cullEnabled ?? false; }
+            set { this.cullEnabled = value; }
+        }
 
         /// <summary>
         ///   Gets or sets a <see cref="FaceCullMode"/> that represents which primitives will not be drawn by the rasterizer.
@@ -91,7 +95,11 @@ namespace FinalEngine.Rendering
         /// <value>
         ///   Which primitives will not be drawn by the rasterizer.
         /// </value>
-        public FaceCullMode FaceCullMode { get; set; }
+        public FaceCullMode FaceCullMode
+        {
+            get { return this.faceCullMode ?? FaceCullMode.Back; }
+            set { this.faceCullMode = value; }
+        }
 
         /// <summary>
         ///   Gets or sets a <see cref="RasterMode"/> that represents how the rasterizer will draw polygons.
@@ -99,14 +107,22 @@ namespace FinalEngine.Rendering
         /// <value>
         ///   How the rasterizer will draw polygons.
         /// </value>
-        public RasterMode FillMode { get; set; }
+        public RasterMode FillMode
+        {
+            get { return this.fillMode ?? RasterMode.Solid; }
+            set { this.fillMode = value; }
+        }
 
         /// <summary>
         ///   Gets or sets a <see cref="WindingDirection"/> that represents the front face of a primitive.
         /// </summary>
         /// <value>
-        ///   The front face of a primitive.
+        ///   The front face of a primitive (the winding draw-order).
         /// </value>
-        public WindingDirection WindingDirection { get; set; }
+        public WindingDirection WindingDirection
+        {
+            get { return this.windingDirection ?? WindingDirection.CounterClockwise; }
+            set { this.windingDirection = value; }
+        }
     }
 }

--- a/FinalEngine.sln
+++ b/FinalEngine.sln
@@ -58,6 +58,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Rendering.Tests", "FinalEngine.Rendering.Tests\FinalEngine.Rendering.Tests.csproj", "{ABFD261F-8A35-459D-9F42-3DC776048D76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -284,6 +286,18 @@ Global
 		{F374D015-E5B0-48A0-9AB9-A521A1550069}.Release|x64.Build.0 = Release|Any CPU
 		{F374D015-E5B0-48A0-9AB9-A521A1550069}.Release|x86.ActiveCfg = Release|Any CPU
 		{F374D015-E5B0-48A0-9AB9-A521A1550069}.Release|x86.Build.0 = Release|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Debug|x64.Build.0 = Debug|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Debug|x86.Build.0 = Debug|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Release|x64.ActiveCfg = Release|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Release|x64.Build.0 = Release|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Release|x86.ActiveCfg = Release|Any CPU
+		{ABFD261F-8A35-459D-9F42-3DC776048D76}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -310,6 +324,7 @@ Global
 		{5444AE2E-DB88-4AE8-BBAA-762A96C7D433} = {ED66C9CD-BA4D-4986-9D02-322433C3D0D3}
 		{CCFA5321-B2B8-47DC-AFDE-3C1FBC42F89B} = {2AF7ECCE-3FB1-47A1-8219-05D0C84E5FB6}
 		{F374D015-E5B0-48A0-9AB9-A521A1550069} = {ED66C9CD-BA4D-4986-9D02-322433C3D0D3}
+		{ABFD261F-8A35-459D-9F42-3DC776048D76} = {ED66C9CD-BA4D-4986-9D02-322433C3D0D3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A278B383-0D14-41B3-A71C-4505E1D503DF}


### PR DESCRIPTION
# Description

This PR fixes #37 for the `RasterStateDescription` type, as it is the only type currently implemented in develop, it's safe to close this issue.

Fixes #37 

## Type of change

- [x] New feature/bug fix??? I dunno

## How Has This Been Tested?

I have provided unit tests for all testable parts of the changed code base.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ, 16GB RAM
* Toolchain: VS Community 2019

## Proposed Design

This PR implements an easier-to-use functionality when it comes to defining default render description states, instead of doing this:

```csharp
rasterizer.SetRasterState(RasterStateDescription.Default);
```

We can now do this:

```csharp
raster.SetRasterState(default);
```

Which makes the code allot more readable and easier to write as well for newcomers.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
