### PR TITLE
[FEATURE] Input Assembler

### DIFF
--- a/FinalEngine.IO/FileSystem.cs
+++ b/FinalEngine.IO/FileSystem.cs
@@ -11,7 +11,7 @@ namespace FinalEngine.IO
     /// <summary>
     ///   Provides a standard implementation of an <see cref="IFileSystem"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.IO.IFileSystem"/>
+    /// <seealso cref="IFileSystem"/>
     public class FileSystem : IFileSystem
     {
         /// <summary>
@@ -33,7 +33,7 @@ namespace FinalEngine.IO
         /// <param name="directory">
         ///   Specifies a <see cref="IDirectoryInvoker"/> that represents the invoker used to handle directory operations.
         /// </param>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="file"/> or <paramref name="directory"/> parameter is null.
         /// </exception>
         public FileSystem(IFileInvoker file, IDirectoryInvoker directory)
@@ -43,7 +43,7 @@ namespace FinalEngine.IO
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="path"/> parameter is null, empty of contains only whitespace characters.
         /// </exception>
         public void CreateDirectory(string path)
@@ -57,7 +57,7 @@ namespace FinalEngine.IO
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="path"/> parameter is null, empty of contains only whitespace characters.
         /// </exception>
         public Stream CreateFile(string path)
@@ -71,7 +71,7 @@ namespace FinalEngine.IO
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="path"/> parameter is null, empty of contains only whitespace characters.
         /// </exception>
         public void DeleteDirectory(string path)
@@ -85,7 +85,7 @@ namespace FinalEngine.IO
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="path"/> parameter is null, empty of contains only whitespace characters.
         /// </exception>
         public void DeleteFile(string path)
@@ -99,7 +99,7 @@ namespace FinalEngine.IO
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="path"/> parameter is null, empty of contains only whitespace characters.
         /// </exception>
         public bool DirectoryExists(string path)
@@ -113,7 +113,7 @@ namespace FinalEngine.IO
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="path"/> parameter is null, empty of contains only whitespace characters.
         /// </exception>
         public bool FileExists(string path)
@@ -127,7 +127,7 @@ namespace FinalEngine.IO
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="path"/> parameter is null, empty of contains only whitespace characters.
         /// </exception>
         public Stream OpenFile(string path, FileAccessMode mode)

--- a/FinalEngine.IO/Invocation/DirectoryInvoker.cs
+++ b/FinalEngine.IO/Invocation/DirectoryInvoker.cs
@@ -10,7 +10,7 @@ namespace FinalEngine.IO.Invocation
     /// <summary>
     ///   Provides an implementation of an <see cref="IDirectoryInvoker"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.IO.Invocation.IDirectoryInvoker"/>
+    /// <seealso cref="IDirectoryInvoker"/>
     [ExcludeFromCodeCoverage]
     public class DirectoryInvoker : IDirectoryInvoker
     {

--- a/FinalEngine.IO/Invocation/FileInvoker.cs
+++ b/FinalEngine.IO/Invocation/FileInvoker.cs
@@ -10,7 +10,7 @@ namespace FinalEngine.IO.Invocation
     /// <summary>
     ///   Provides an implementation ofa n <see cref="IFileInvoker"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.IO.Invocation.IFileInvoker"/>
+    /// <seealso cref="IFileInvoker"/>
     [ExcludeFromCodeCoverage]
     public class FileInvoker : IFileInvoker
     {

--- a/FinalEngine.Input/Keyboard/KeyEventArgs.cs
+++ b/FinalEngine.Input/Keyboard/KeyEventArgs.cs
@@ -9,7 +9,7 @@ namespace FinalEngine.Input.Keyboard
     /// <summary>
     ///   Provides event data for the <see cref="IKeyboardDevice.KeyUp"/> and <see cref="IKeyboardDevice.KeyDown"/> events.
     /// </summary>
-    /// <seealso cref="System.EventArgs"/>
+    /// <seealso cref="EventArgs"/>
     public class KeyEventArgs : EventArgs
     {
         /// <summary>

--- a/FinalEngine.Input/Keyboard/Keyboard.cs
+++ b/FinalEngine.Input/Keyboard/Keyboard.cs
@@ -10,7 +10,7 @@ namespace FinalEngine.Input.Keyboard
     /// <summary>
     ///   Provides a standard implementation of an <see cref="IKeyboard"/>, that interfaces with an <see cref="IKeyboardDevice"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.Input.Keyboard.IKeyboard"/>
+    /// <seealso cref="IKeyboard"/>
     public class Keyboard : IKeyboard
     {
         /// <summary>

--- a/FinalEngine.Input/Mouse/Mouse.cs
+++ b/FinalEngine.Input/Mouse/Mouse.cs
@@ -11,7 +11,7 @@ namespace FinalEngine.Input.Mouse
     /// <summary>
     ///   Provides a standard implementation of an <see cref="IMouse"/>, that interfaces with an <see cref="IMouseDevice"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.Input.Mouse.IMouse"/>
+    /// <seealso cref="IMouse"/>
     public class Mouse : IMouse
     {
         /// <summary>

--- a/FinalEngine.Input/Mouse/MouseButtonEventArgs.cs
+++ b/FinalEngine.Input/Mouse/MouseButtonEventArgs.cs
@@ -9,7 +9,7 @@ namespace FinalEngine.Input.Mouse
     /// <summary>
     ///   Provides event data for the <see cref="IMouseDevice.ButtonUp"/> and <see cref="IMouseDevice.ButtonDown"/> events.
     /// </summary>
-    /// <seealso cref="System.EventArgs"/>
+    /// <seealso cref="EventArgs"/>
     public class MouseButtonEventArgs : EventArgs
     {
         /// <summary>

--- a/FinalEngine.Input/Mouse/MouseMoveEventArgs.cs
+++ b/FinalEngine.Input/Mouse/MouseMoveEventArgs.cs
@@ -10,7 +10,7 @@ namespace FinalEngine.Input.Mouse
     /// <summary>
     ///   Provides event data for the <see cref="IMouseDevice.Move"/> event.
     /// </summary>
-    /// <seealso cref="System.EventArgs"/>
+    /// <seealso cref="EventArgs"/>
     public class MouseMoveEventArgs : EventArgs
     {
         /// <summary>

--- a/FinalEngine.Input/Mouse/MouseScrollEventArgs.cs
+++ b/FinalEngine.Input/Mouse/MouseScrollEventArgs.cs
@@ -9,7 +9,7 @@ namespace FinalEngine.Input.Mouse
     /// <summary>
     ///   Provides event data for the <see cref="IMouseDevice.Scroll"/> event.
     /// </summary>
-    /// <seealso cref="System.EventArgs"/>
+    /// <seealso cref="EventArgs"/>
     public class MouseScrollEventArgs : EventArgs
     {
         /// <summary>

--- a/FinalEngine.Platform.Desktop/OpenTK/OpenTKKeyboardDevice.cs
+++ b/FinalEngine.Platform.Desktop/OpenTK/OpenTKKeyboardDevice.cs
@@ -12,7 +12,7 @@ namespace FinalEngine.Platform.Desktop.OpenTK
     /// <summary>
     ///   Provides an OpenTK implementation of an <see cref="IKeyboardDevice"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.Input.Keyboard.IKeyboardDevice"/>
+    /// <seealso cref="IKeyboardDevice"/>
     public class OpenTKKeyboardDevice : IKeyboardDevice
     {
         /// <summary>

--- a/FinalEngine.Platform.Desktop/OpenTK/OpenTKMouseDevice.cs
+++ b/FinalEngine.Platform.Desktop/OpenTK/OpenTKMouseDevice.cs
@@ -16,7 +16,7 @@ namespace FinalEngine.Platform.Desktop.OpenTK
     /// <summary>
     ///   Provides an OpenTK implementation of an <see cref="IMouseDevice"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.Input.Mouse.IMouseDevice"/>
+    /// <seealso cref="IMouseDevice"/>
     public class OpenTKMouseDevice : IMouseDevice
     {
         /// <summary>

--- a/FinalEngine.Platform.Desktop/OpenTK/OpenTKWindow.cs
+++ b/FinalEngine.Platform.Desktop/OpenTK/OpenTKWindow.cs
@@ -10,8 +10,8 @@ namespace FinalEngine.Platform.Desktop.OpenTK
     /// <summary>
     ///   Provides an OpenTK implementation of an <see cref="IWindow"/> and <see cref="IEventsProcessor"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.Platform.IWindow"/>
-    /// <seealso cref="FinalEngine.Platform.IEventsProcessor"/>
+    /// <seealso cref="IWindow"/>
+    /// <seealso cref="IEventsProcessor"/>
     public class OpenTKWindow : IWindow, IEventsProcessor
     {
         /// <summary>
@@ -25,7 +25,7 @@ namespace FinalEngine.Platform.Desktop.OpenTK
         /// <param name="nativeWindow">
         ///   Specifies a <see cref="INativeWindowInvoker"/> that represents the underlying native window to be used.
         /// </param>
-        /// <exception cref="System.ArgumentNullException">
+        /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="nativeWindow"/> parameter is null.
         /// </exception>
         public OpenTKWindow(INativeWindowInvoker nativeWindow)
@@ -48,7 +48,7 @@ namespace FinalEngine.Platform.Desktop.OpenTK
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ObjectDisposedException">
+        /// <exception cref="ObjectDisposedException">
         ///   The underlying native window is dispsoed.
         /// </exception>
         public string Title
@@ -70,7 +70,7 @@ namespace FinalEngine.Platform.Desktop.OpenTK
         }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ObjectDisposedException">
+        /// <exception cref="ObjectDisposedException">
         ///   The underlying native window is dispsoed.
         /// </exception>
         public bool Visible
@@ -100,7 +100,7 @@ namespace FinalEngine.Platform.Desktop.OpenTK
         protected bool IsDisposed { get; private set; }
 
         /// <inheritdoc/>
-        /// <exception cref="System.ObjectDisposedException">
+        /// <exception cref="ObjectDisposedException">
         ///   The underlying native window is dispsoed.
         /// </exception>
         public void Close()
@@ -124,7 +124,7 @@ namespace FinalEngine.Platform.Desktop.OpenTK
         /// <remarks>
         ///   This method is not thread safe and should only be executed on the main thread.
         /// </remarks>
-        /// <exception cref="System.ObjectDisposedException">
+        /// <exception cref="ObjectDisposedException">
         ///   The underlying native window is dispsoed.
         /// </exception>
         public void ProcessEvents()

--- a/FinalEngine.Platform.Desktop/OpenTK/OpenTKWindow.cs
+++ b/FinalEngine.Platform.Desktop/OpenTK/OpenTKWindow.cs
@@ -5,7 +5,6 @@
 namespace FinalEngine.Platform.Desktop.OpenTK
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using FinalEngine.Platform.Desktop.OpenTK.Invocation;
 
     /// <summary>
@@ -37,7 +36,6 @@ namespace FinalEngine.Platform.Desktop.OpenTK
         /// <summary>
         ///   Finalizes an instance of the <see cref="OpenTKWindow"/> class.
         /// </summary>
-        [ExcludeFromCodeCoverage]
         ~OpenTKWindow()
         {
             this.Dispose(false);
@@ -145,7 +143,6 @@ namespace FinalEngine.Platform.Desktop.OpenTK
         /// <param name="disposing">
         ///   <c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.
         /// </param>
-        [ExcludeFromCodeCoverage]
         protected virtual void Dispose(bool disposing)
         {
             if (this.IsDisposed)

--- a/FinalEngine.Platform/IWindow.cs
+++ b/FinalEngine.Platform/IWindow.cs
@@ -9,7 +9,7 @@ namespace FinalEngine.Platform
     /// <summary>
     ///   Defines an interface that represents a display or window.
     /// </summary>
-    /// <seealso cref="System.IDisposable"/>
+    /// <seealso cref="IDisposable"/>
     public interface IWindow : IDisposable
     {
         /// <summary>

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLIndexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLIndexBuffer.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IOpenGLIndexBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.OpenGL.Buffers
+{
+    using FinalEngine.Rendering.Buffers;
+
+    public interface IOpenGLIndexBuffer : IIndexBuffer
+    {
+        void Bind();
+    }
+}

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLInputLayout.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLInputLayout.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IOpenGLInputLayout.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.OpenGL.Buffers
+{
+    using FinalEngine.Rendering.Buffers;
+
+    public interface IOpenGLInputLayout : IInputLayout
+    {
+        void Bind();
+    }
+}

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLInputLayout.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLInputLayout.cs
@@ -9,5 +9,7 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
     public interface IOpenGLInputLayout : IInputLayout
     {
         void Bind();
+
+        void Reset();
     }
 }

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IOpenGLVertexBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.OpenGL.Buffers
+{
+    using FinalEngine.Rendering.Buffers;
+
+    public interface IOpenGLVertexBuffer : IVertexBuffer
+    {
+        void Bind();
+    }
+}

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="OpenGLIndexBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.OpenGL.Buffers
+{
+    using System;
+    using FinalEngine.Rendering.OpenGL.Invocation;
+    using OpenTK.Graphics.OpenGL4;
+
+    public class OpenGLIndexBuffer<T> : IOpenGLIndexBuffer
+        where T : struct
+    {
+        private readonly IOpenGLInvoker invoker;
+
+        private int id;
+
+        public OpenGLIndexBuffer(IOpenGLInvoker invoker, T[] data, int sizeInBytes)
+        {
+            this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
+            }
+
+            this.Length = data.Length;
+
+            this.id = invoker.GenBuffer();
+
+            invoker.BindBuffer(BufferTarget.ElementArrayBuffer, this.id);
+            invoker.BufferData(BufferTarget.ElementArrayBuffer, sizeInBytes, data, BufferUsageHint.StaticDraw);
+            invoker.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
+        }
+
+        ~OpenGLIndexBuffer()
+        {
+            this.Dispose(false);
+        }
+
+        public int Length { get; }
+
+        protected bool IsDisposed { get; private set; }
+
+        public void Bind()
+        {
+            if (this.IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(OpenGLIndexBuffer<T>));
+            }
+
+            this.invoker.BindBuffer(BufferTarget.ElementArrayBuffer, this.id);
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.IsDisposed)
+            {
+                return;
+            }
+
+            if (disposing && this.id != -1)
+            {
+                this.invoker.DeleteBuffer(this.id);
+                this.id = -1;
+            }
+
+            this.IsDisposed = true;
+        }
+    }
+}

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLInputLayout.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLInputLayout.cs
@@ -16,8 +16,8 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
 
         public OpenGLInputLayout(IOpenGLInvoker invoker, IEnumerable<InputElement> elements)
         {
-            this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
-            this.Elements = elements ?? throw new ArgumentNullException(nameof(elements));
+            this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
+            this.Elements = elements ?? throw new ArgumentNullException(nameof(elements), $"The specified {nameof(elements)} parameter cannot be null.");
         }
 
         public IEnumerable<InputElement> Elements { get; }

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLInputLayout.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLInputLayout.cs
@@ -1,0 +1,59 @@
+﻿// <copyright file="OpenGLInputLayout.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.OpenGL.Buffers
+{
+    using System;
+    using System.Collections.Generic;
+    using FinalEngine.Rendering.Buffers;
+    using FinalEngine.Rendering.OpenGL.Invocation;
+    using OpenTK.Graphics.OpenGL4;
+
+    public class OpenGLInputLayout : IOpenGLInputLayout
+    {
+        private readonly IOpenGLInvoker invoker;
+
+        public OpenGLInputLayout(IOpenGLInvoker invoker, IEnumerable<InputElement> elements)
+        {
+            this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker));
+            this.Elements = elements ?? throw new ArgumentNullException(nameof(elements));
+        }
+
+        public IEnumerable<InputElement> Elements { get; }
+
+        public void Bind()
+        {
+            foreach (InputElement element in this.Elements)
+            {
+                this.invoker.VertexAttribFormat(element.Index, element.Size, GetVertexAttribType(element.Type), false, element.RelativeOffset);
+                this.invoker.VertexAttribBinding(element.Index, 0);
+                this.invoker.EnableVertexAttribArray(element.Index);
+            }
+        }
+
+        private static VertexAttribType GetVertexAttribType(InputElementType type)
+        {
+            switch (type)
+            {
+                case InputElementType.Byte:
+                    return VertexAttribType.Byte;
+
+                case InputElementType.Double:
+                    return VertexAttribType.Double;
+
+                case InputElementType.Float:
+                    return VertexAttribType.Float;
+
+                case InputElementType.Int:
+                    return VertexAttribType.Int;
+
+                case InputElementType.Short:
+                    return VertexAttribType.Short;
+
+                default:
+                    throw new NotSupportedException($"The specified {nameof(type)} is not supported by the OpenGL Backend.");
+            }
+        }
+    }
+}

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLInputLayout.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLInputLayout.cs
@@ -32,6 +32,14 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
             }
         }
 
+        public void Reset()
+        {
+            foreach (InputElement element in this.Elements)
+            {
+                this.invoker.DisableVertexAttribArray(element.Index);
+            }
+        }
+
         private static VertexAttribType GetVertexAttribType(InputElementType type)
         {
             switch (type)

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="OpenGLVertexBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.OpenGL.Buffers
+{
+    using System;
+    using FinalEngine.Rendering.OpenGL.Invocation;
+    using OpenTK.Graphics.OpenGL4;
+
+    public class OpenGLVertexBuffer<T> : IOpenGLVertexBuffer
+        where T : struct
+    {
+        private readonly IOpenGLInvoker invoker;
+
+        private int id;
+
+        public OpenGLVertexBuffer(IOpenGLInvoker invoker, T[] data, int sizeInBytes, int stride)
+        {
+            this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
+            }
+
+            this.Stride = stride;
+
+            this.id = invoker.GenBuffer();
+
+            invoker.BindBuffer(BufferTarget.ArrayBuffer, this.id);
+            invoker.BufferData(BufferTarget.ArrayBuffer, sizeInBytes, data, BufferUsageHint.StaticDraw);
+            invoker.BindBuffer(BufferTarget.ArrayBuffer, 0);
+        }
+
+        ~OpenGLVertexBuffer()
+        {
+            this.Dispose(false);
+        }
+
+        public int Stride { get; }
+
+        protected bool IsDisposed { get; private set; }
+
+        public void Bind()
+        {
+            if (this.IsDisposed)
+            {
+                throw new ObjectDisposedException(nameof(OpenGLVertexBuffer<T>));
+            }
+
+            this.invoker.BindVertexBuffer(0, this.id, IntPtr.Zero, this.Stride);
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.IsDisposed)
+            {
+                return;
+            }
+
+            if (disposing && this.id != -1)
+            {
+                this.invoker.DeleteBuffer(this.id);
+                this.id = -1;
+            }
+
+            this.IsDisposed = true;
+        }
+    }
+}

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -4,6 +4,7 @@
 
 namespace FinalEngine.Rendering.OpenGL.Invocation
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Drawing;
     using OpenTK;
@@ -16,6 +17,15 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
     {
         /// <inheritdoc cref="GL.AttachShader(int, int)"/>
         void AttachShader(int program, int shader);
+
+        /// <inheritdoc cref="GL.BindBuffer(BufferTarget, int)"/>
+        void BindBuffer(BufferTarget target, int buffer);
+
+        /// <inheritdoc cref="GL.BindVertexBuffer(int, int, IntPtr, int)"/>
+        void BindVertexBuffer(int bindingindex, int buffer, IntPtr offset, int stride);
+
+        /// <inheritdoc cref="GL.BufferData{T2}(BufferTarget, int, T2[], BufferUsageHint)"/>
+        void BufferData<T2>(BufferTarget target, int size, T2[] data, BufferUsageHint usage);
 
         /// <inheritdoc cref="GL.Clear(ClearBufferMask)"/>
         void Clear(ClearBufferMask mask);
@@ -41,6 +51,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.CullFace(CullFaceMode)"/>
         void CullFace(CullFaceMode mode);
 
+        /// <inheritdoc cref="GL.DeleteBuffer(int)"/>
+        void DeleteBuffer(int buffers);
+
         /// <inheritdoc cref="GL.DeleteProgram(int)"/>
         void DeleteProgram(int program);
 
@@ -58,6 +71,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
 
         /// <inheritdoc cref="GL.FrontFace(FrontFaceDirection)"/>
         void FrontFace(FrontFaceDirection mode);
+
+        /// <inheritdoc cref="GL.GenBuffer"/>
+        int GenBuffer();
 
         /// <inheritdoc cref="GL.GetProgramInfoLog(int)"/>
         string GetProgramInfoLog(int program);

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -70,6 +70,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.Disable(EnableCap)"/>
         void Disable(EnableCap cap);
 
+        /// <inheritdoc cref="GL.DisableVertexAttribArray(int)"/>
+        void DisableVertexAttribArray(int index);
+
         /// <inheritdoc cref="GL.DrawElements(PrimitiveType, int, DrawElementsType, int)"/>
         void DrawElements(PrimitiveType mode, int count, DrawElementsType type, int indices);
 

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -70,6 +70,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.Enable(EnableCap)"/>
         void Enable(EnableCap cap);
 
+        /// <inheritdoc cref="GL.EnableVertexAttribArray(int)"/>
+        void EnableVertexAttribArray(int index);
+
         /// <inheritdoc cref="GL.FrontFace(FrontFaceDirection)"/>
         void FrontFace(FrontFaceDirection mode);
 
@@ -128,6 +131,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
 
         /// <inheritdoc cref="GL.ValidateProgram(int)"/>
         void ValidateProgram(int program);
+
+        /// <inheritdoc cref="GL.VertexAttribBinding(int, int)"/>
+        void VertexAttribBinding(int attribindex, int bindingindex);
+
+        /// <inheritdoc cref="GL.VertexAttribFormat(int, int, VertexAttribType, bool, int)"/>
+        void VertexAttribFormat(int attribindex, int size, VertexAttribType type, bool normalized, int relativeoffset);
 
         /// <inheritdoc cref="GL.Viewport(Rectangle)"/>
         void Viewport(Rectangle rectangle);

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -21,6 +21,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.BindBuffer(BufferTarget, int)"/>
         void BindBuffer(BufferTarget target, int buffer);
 
+        /// <inheritdoc cref="GL.BindVertexArray(int)"/>
+        void BindVertexArray(int array);
+
         /// <inheritdoc cref="GL.BindVertexBuffer(int, int, IntPtr, int)"/>
         void BindVertexBuffer(int bindingindex, int buffer, IntPtr offset, int stride);
 
@@ -61,6 +64,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.DeleteShader(int)"/>
         void DeleteShader(int shader);
 
+        /// <inheritdoc cref="GL.DeleteVertexArray(int)"/>
+        void DeleteVertexArray(int arrays);
+
         /// <inheritdoc cref="GL.Disable(EnableCap)"/>
         void Disable(EnableCap cap);
 
@@ -78,6 +84,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
 
         /// <inheritdoc cref="GL.GenBuffer"/>
         int GenBuffer();
+
+        /// <inheritdoc cref="GL.GenVertexArray"/>
+        int GenVertexArray();
 
         /// <inheritdoc cref="GL.GetProgramInfoLog(int)"/>
         string GetProgramInfoLog(int program);

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -25,7 +25,8 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         void BindVertexBuffer(int bindingindex, int buffer, IntPtr offset, int stride);
 
         /// <inheritdoc cref="GL.BufferData{T2}(BufferTarget, int, T2[], BufferUsageHint)"/>
-        void BufferData<T2>(BufferTarget target, int size, T2[] data, BufferUsageHint usage);
+        void BufferData<T2>(BufferTarget target, int size, T2[] data, BufferUsageHint usage)
+            where T2 : struct;
 
         /// <inheritdoc cref="GL.Clear(ClearBufferMask)"/>
         void Clear(ClearBufferMask mask);

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -127,6 +127,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         }
 
         /// <inheritdoc/>
+        public void DisableVertexAttribArray(int index)
+        {
+            GL.DisableVertexAttribArray(index);
+        }
+
+        /// <inheritdoc/>
         public void DrawElements(PrimitiveType mode, int count, DrawElementsType type, int indices)
         {
             GL.DrawElements(mode, count, type, indices);

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -13,7 +13,7 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
     /// <summary>
     ///   Provides an OpenTK implementation of an <see cref="IOpenGLInvoker"/>.
     /// </summary>
-    /// <seealso cref="FinalEngine.Rendering.OpenGL.Invocation.IOpenGLInvoker"/>
+    /// <seealso cref="IOpenGLInvoker"/>
     [ExcludeFromCodeCoverage]
     public class OpenGLInvoker : IOpenGLInvoker
     {
@@ -45,7 +45,7 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public void BufferData<T2>(BufferTarget target, int size, T2[] data, BufferUsageHint usage)
             where T2 : struct
         {
-            GL.BufferData<T2>(target, size, data, usage);
+            GL.BufferData(target, size, data, usage);
         }
 
         /// <inheritdoc/>

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -30,6 +30,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         }
 
         /// <inheritdoc/>
+        public void BindVertexArray(int array)
+        {
+            GL.BindVertexArray(array);
+        }
+
+        /// <inheritdoc/>
         public void BindVertexBuffer(int bindingindex, int buffer, IntPtr offset, int stride)
         {
             GL.BindVertexBuffer(bindingindex, buffer, offset, stride);
@@ -109,6 +115,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         }
 
         /// <inheritdoc/>
+        public void DeleteVertexArray(int arrays)
+        {
+            GL.DeleteVertexArray(arrays);
+        }
+
+        /// <inheritdoc/>
         public void Disable(EnableCap cap)
         {
             GL.Disable(cap);
@@ -127,6 +139,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         }
 
         /// <inheritdoc/>
+        public void EnableVertexAttribArray(int index)
+        {
+            GL.EnableVertexAttribArray(index);
+        }
+
+        /// <inheritdoc/>
         public void FrontFace(FrontFaceDirection mode)
         {
             GL.FrontFace(mode);
@@ -136,6 +154,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public int GenBuffer()
         {
             return GL.GenBuffer();
+        }
+
+        /// <inheritdoc/>
+        public int GenVertexArray()
+        {
+            return GL.GenVertexArray();
         }
 
         /// <inheritdoc/>
@@ -238,6 +262,18 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public void ValidateProgram(int program)
         {
             GL.ValidateProgram(program);
+        }
+
+        /// <inheritdoc/>
+        public void VertexAttribBinding(int attribindex, int bindingindex)
+        {
+            GL.VertexAttribBinding(attribindex, bindingindex);
+        }
+
+        /// <inheritdoc/>
+        public void VertexAttribFormat(int attribindex, int size, VertexAttribType type, bool normalized, int relativeoffset)
+        {
+            GL.VertexAttribFormat(attribindex, size, type, normalized, relativeoffset);
         }
 
         /// <inheritdoc/>

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -4,6 +4,7 @@
 
 namespace FinalEngine.Rendering.OpenGL.Invocation
 {
+    using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Drawing;
     using OpenTK;
@@ -20,6 +21,25 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public void AttachShader(int program, int shader)
         {
             GL.AttachShader(program, shader);
+        }
+
+        /// <inheritdoc/>
+        public void BindBuffer(BufferTarget target, int buffer)
+        {
+            GL.BindBuffer(target, buffer);
+        }
+
+        /// <inheritdoc/>
+        public void BindVertexBuffer(int bindingindex, int buffer, IntPtr offset, int stride)
+        {
+            GL.BindVertexBuffer(bindingindex, buffer, offset, stride);
+        }
+
+        /// <inheritdoc/>
+        public void BufferData<T2>(BufferTarget target, int size, T2[] data, BufferUsageHint usage)
+            where T2 : struct
+        {
+            GL.BufferData<T2>(target, size, data, usage);
         }
 
         /// <inheritdoc/>
@@ -71,6 +91,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         }
 
         /// <inheritdoc/>
+        public void DeleteBuffer(int buffers)
+        {
+            GL.DeleteBuffer(buffers);
+        }
+
+        /// <inheritdoc/>
         public void DeleteProgram(int program)
         {
             GL.DeleteProgram(program);
@@ -104,6 +130,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public void FrontFace(FrontFaceDirection mode)
         {
             GL.FrontFace(mode);
+        }
+
+        /// <inheritdoc/>
+        public int GenBuffer()
+        {
+            return GL.GenBuffer();
         }
 
         /// <inheritdoc/>

--- a/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
@@ -7,6 +7,8 @@ namespace FinalEngine.Rendering.OpenGL
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using FinalEngine.Rendering.Buffers;
+    using FinalEngine.Rendering.OpenGL.Buffers;
     using FinalEngine.Rendering.OpenGL.Invocation;
     using FinalEngine.Rendering.OpenGL.Pipeline;
     using FinalEngine.Rendering.Pipeline;
@@ -18,6 +20,27 @@ namespace FinalEngine.Rendering.OpenGL
         public OpenGLGPUResourceFactory(IOpenGLInvoker invoker)
         {
             this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
+        }
+
+        public IIndexBuffer CreateIndexBuffer<T>(T[] data, int sizeInBytes)
+            where T : struct
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
+            }
+
+            return new OpenGLIndexBuffer<T>(this.invoker, data, sizeInBytes);
+        }
+
+        public IInputLayout CreateInputLayout(IEnumerable<InputElement> elements)
+        {
+            if (elements == null)
+            {
+                throw new ArgumentNullException(nameof(elements), $"The specified {nameof(elements)} parameter cannot be null.");
+            }
+
+            return new OpenGLInputLayout(this.invoker, elements);
         }
 
         public IShader CreateShader(PipelineTarget target, string sourceCode)
@@ -38,6 +61,17 @@ namespace FinalEngine.Rendering.OpenGL
             }
 
             return new OpenGLShaderProgram(this.invoker, shaders.Cast<IOpenGLShader>());
+        }
+
+        public IVertexBuffer CreateVertexBuffer<T>(T[] data, int sizeInBytes, int stride)
+            where T : struct
+        {
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
+            }
+
+            return new OpenGLVertexBuffer<T>(this.invoker, data, sizeInBytes, stride);
         }
     }
 }

--- a/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="OpenGLInputAssembler.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.OpenGL
+{
+    using System;
+    using FinalEngine.Rendering.Buffers;
+    using FinalEngine.Rendering.OpenGL.Buffers;
+
+    public class OpenGLInputAssembler : IInputAssembler
+    {
+        public void SetIndexBuffer(IIndexBuffer buffer)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (buffer is not IOpenGLIndexBuffer glIndexBuffer)
+            {
+                throw new ArgumentException($"The specified {nameof(buffer)} parameter is not of type {nameof(IOpenGLIndexBuffer)}.");
+            }
+
+            glIndexBuffer.Bind();
+        }
+
+        public void SetInputLayout(IInputLayout layout)
+        {
+            //// TODO: Make sure all vertex attribute bindings are set back to normal when setting a new input layout.
+
+            if (layout == null)
+            {
+                throw new ArgumentNullException(nameof(layout));
+            }
+
+            if (layout is not IOpenGLInputLayout glInputLayout)
+            {
+                throw new ArgumentException($"The specified {nameof(layout)} parameter is not of type {nameof(IOpenGLInputLayout)}.");
+            }
+
+            glInputLayout.Bind();
+        }
+
+        public void SetVertexBuffer(IVertexBuffer buffer)
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer));
+            }
+
+            if (buffer is not IOpenGLVertexBuffer glVertexBuffer)
+            {
+                throw new ArgumentException($"The specified {nameof(buffer)} parameter is not of type {nameof(IOpenGLVertexBuffer)}.");
+            }
+
+            glVertexBuffer.Bind();
+        }
+    }
+}

--- a/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
@@ -16,7 +16,7 @@ namespace FinalEngine.Rendering.OpenGL
         {
             if (buffer == null)
             {
-                throw new ArgumentNullException(nameof(buffer));
+                throw new ArgumentNullException(nameof(buffer), $"The specified {nameof(buffer)} parameter cannot be null.");
             }
 
             if (buffer is not IOpenGLIndexBuffer glIndexBuffer)
@@ -31,7 +31,7 @@ namespace FinalEngine.Rendering.OpenGL
         {
             if (layout == null)
             {
-                throw new ArgumentNullException(nameof(layout));
+                throw new ArgumentNullException(nameof(layout), $"The specified {nameof(layout)} parameter cannot be null.");
             }
 
             if (layout is not IOpenGLInputLayout glInputLayout)
@@ -49,7 +49,7 @@ namespace FinalEngine.Rendering.OpenGL
         {
             if (buffer == null)
             {
-                throw new ArgumentNullException(nameof(buffer));
+                throw new ArgumentNullException(nameof(buffer), $"The specified {nameof(buffer)} parameter cannot be null.");
             }
 
             if (buffer is not IOpenGLVertexBuffer glVertexBuffer)

--- a/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
@@ -10,6 +10,8 @@ namespace FinalEngine.Rendering.OpenGL
 
     public class OpenGLInputAssembler : IInputAssembler
     {
+        private IOpenGLInputLayout? boundLayout;
+
         public void SetIndexBuffer(IIndexBuffer buffer)
         {
             if (buffer == null)
@@ -27,8 +29,6 @@ namespace FinalEngine.Rendering.OpenGL
 
         public void SetInputLayout(IInputLayout layout)
         {
-            //// TODO: Make sure all vertex attribute bindings are set back to normal when setting a new input layout.
-
             if (layout == null)
             {
                 throw new ArgumentNullException(nameof(layout));
@@ -39,7 +39,10 @@ namespace FinalEngine.Rendering.OpenGL
                 throw new ArgumentException($"The specified {nameof(layout)} parameter is not of type {nameof(IOpenGLInputLayout)}.");
             }
 
-            glInputLayout.Bind();
+            this.boundLayout?.Reset();
+
+            this.boundLayout = glInputLayout;
+            this.boundLayout.Bind();
         }
 
         public void SetVertexBuffer(IVertexBuffer buffer)

--- a/FinalEngine.Rendering.OpenGL/OpenGLRenderContext.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLRenderContext.cs
@@ -13,12 +13,13 @@ namespace FinalEngine.Rendering.OpenGL
     {
         private readonly IGraphicsContext context;
 
+        private readonly IOpenGLInvoker invoker;
+
+        private int vao;
+
         public OpenGLRenderContext(IOpenGLInvoker invoker, IBindingsContext bindings, IGraphicsContext context)
         {
-            if (invoker == null)
-            {
-                throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
-            }
+            this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
 
             if (bindings == null)
             {
@@ -29,6 +30,22 @@ namespace FinalEngine.Rendering.OpenGL
 
             context.MakeCurrent();
             invoker.LoadBindings(bindings);
+
+            this.vao = invoker.GenVertexArray();
+            invoker.BindVertexArray(this.vao);
+        }
+
+        ~OpenGLRenderContext()
+        {
+            this.Dispose(false);
+        }
+
+        protected bool IsDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         public void SwapBuffers()
@@ -39,6 +56,22 @@ namespace FinalEngine.Rendering.OpenGL
             }
 
             this.context.SwapBuffers();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (this.IsDisposed)
+            {
+                return;
+            }
+
+            if (disposing && this.vao != -1)
+            {
+                this.invoker.DeleteVertexArray(this.vao);
+                this.vao = -1;
+            }
+
+            this.IsDisposed = true;
         }
     }
 }

--- a/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
@@ -19,10 +19,13 @@ namespace FinalEngine.Rendering.OpenGL
 
             this.Rasterizer = new OpenGLRasterizer(invoker);
             this.Pipeline = new OpenGLPipeline(invoker);
+            this.InputAssembler = new OpenGLInputAssembler();
             this.Factory = new OpenGLGPUResourceFactory(invoker);
         }
 
         public IGPUResourceFactory Factory { get; }
+
+        public IInputAssembler InputAssembler { get; }
 
         public IPipeline Pipeline { get; }
 

--- a/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShader.cs
+++ b/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShader.cs
@@ -5,7 +5,6 @@
 namespace FinalEngine.Rendering.OpenGL.Pipeline
 {
     using System;
-    using System.Diagnostics.CodeAnalysis;
     using FinalEngine.Rendering.OpenGL.Invocation;
     using FinalEngine.Rendering.Pipeline;
     using OpenTK.Graphics.OpenGL4;
@@ -56,7 +55,6 @@ namespace FinalEngine.Rendering.OpenGL.Pipeline
             }
         }
 
-        [ExcludeFromCodeCoverage]
         ~OpenGLShader()
         {
             this.Dispose(false);

--- a/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShaderProgram.cs
+++ b/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShaderProgram.cs
@@ -25,11 +25,6 @@ namespace FinalEngine.Rendering.OpenGL.Pipeline
 
             this.id = this.invoker.CreateProgram();
 
-            //// TODO: Should we make sure the user creates a program with both a vertex and fragment shader?
-            //// TODO: How should we handle errors and warnings? Perhaps we need a way to decipher them and print out our own errors or warnings?
-            //// TODO: I think the best way to handle this is to log information and say which framework has caused the error.
-            //// TODO: Gradually, I can provide more context as to why the error has occurred.
-
             foreach (IOpenGLShader? shader in shaders)
             {
                 if (shader == null)

--- a/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShaderProgram.cs
+++ b/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShaderProgram.cs
@@ -6,7 +6,6 @@ namespace FinalEngine.Rendering.OpenGL.Pipeline
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics.CodeAnalysis;
     using FinalEngine.Rendering.OpenGL.Invocation;
 
     public class OpenGLShaderProgram : IOpenGLShaderProgram
@@ -53,7 +52,6 @@ namespace FinalEngine.Rendering.OpenGL.Pipeline
             }
         }
 
-        [ExcludeFromCodeCoverage]
         ~OpenGLShaderProgram()
         {
             this.Dispose(false);

--- a/FinalEngine.Rendering/Buffers/IIndexBuffer.cs
+++ b/FinalEngine.Rendering/Buffers/IIndexBuffer.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IIndexBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.Buffers
+{
+    using System;
+
+    public interface IIndexBuffer : IDisposable
+    {
+        int Length { get; }
+    }
+}

--- a/FinalEngine.Rendering/Buffers/IInputLayout.cs
+++ b/FinalEngine.Rendering/Buffers/IInputLayout.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IInputLayout.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.Buffers
+{
+    using System.Collections.Generic;
+
+    public interface IInputLayout
+    {
+        IEnumerable<InputElement> Elements { get; }
+    }
+}

--- a/FinalEngine.Rendering/Buffers/IVertexBuffer.cs
+++ b/FinalEngine.Rendering/Buffers/IVertexBuffer.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="IVertexBuffer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.Buffers
+{
+    using System;
+
+    public interface IVertexBuffer : IDisposable
+    {
+        int Stride { get; }
+    }
+}

--- a/FinalEngine.Rendering/Buffers/InputElement.cs
+++ b/FinalEngine.Rendering/Buffers/InputElement.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="InputElement.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.Buffers
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    [SuppressMessage("Naming", "CA1720:Identifier contains type name", Justification = "Required for API")]
+    public enum InputElementType
+    {
+        Int,
+
+        Byte,
+
+        Short,
+
+        Float,
+
+        Double,
+    }
+
+    public struct InputElement
+    {
+        public InputElement(int index, int size, InputElementType type, int relativeOffset)
+        {
+            this.Index = index;
+            this.Size = size;
+            this.Type = type;
+            this.RelativeOffset = relativeOffset;
+        }
+
+        public int Index { get; set; }
+
+        public int RelativeOffset { get; set; }
+
+        public int Size { get; set; }
+
+        public InputElementType Type { get; set; }
+    }
+}

--- a/FinalEngine.Rendering/IGPUResourceFactory.cs
+++ b/FinalEngine.Rendering/IGPUResourceFactory.cs
@@ -5,12 +5,21 @@
 namespace FinalEngine.Rendering
 {
     using System.Collections.Generic;
+    using FinalEngine.Rendering.Buffers;
     using FinalEngine.Rendering.Pipeline;
 
     public interface IGPUResourceFactory
     {
+        IIndexBuffer CreateIndexBuffer<T>(T[] data, int sizeInBytes)
+            where T : struct;
+
+        IInputLayout CreateInputLayout(IEnumerable<InputElement> elements);
+
         IShader CreateShader(PipelineTarget target, string sourceCode);
 
         IShaderProgram CreateShaderProgram(IEnumerable<IShader> shaders);
+
+        IVertexBuffer CreateVertexBuffer<T>(T[] data, int sizeInBytes, int stride)
+            where T : struct;
     }
 }

--- a/FinalEngine.Rendering/IInputAssembler.cs
+++ b/FinalEngine.Rendering/IInputAssembler.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="IInputAssembler.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering
+{
+    using FinalEngine.Rendering.Buffers;
+
+    public interface IInputAssembler
+    {
+        void SetIndexBuffer(IIndexBuffer buffer);
+
+        void SetInputLayout(IInputLayout layout);
+
+        void SetVertexBuffer(IVertexBuffer buffer);
+    }
+}

--- a/FinalEngine.Rendering/IRenderContext.cs
+++ b/FinalEngine.Rendering/IRenderContext.cs
@@ -4,7 +4,9 @@
 
 namespace FinalEngine.Rendering
 {
-    public interface IRenderContext
+    using System;
+
+    public interface IRenderContext : IDisposable
     {
         void SwapBuffers();
     }

--- a/FinalEngine.Rendering/IRenderDevice.cs
+++ b/FinalEngine.Rendering/IRenderDevice.cs
@@ -21,6 +21,8 @@ namespace FinalEngine.Rendering
     {
         IGPUResourceFactory Factory { get; }
 
+        IInputAssembler InputAssembler { get; }
+
         IPipeline Pipeline { get; }
 
         IRasterizer Rasterizer { get; }

--- a/FinalEngine.Rendering/Pipeline/IShader.cs
+++ b/FinalEngine.Rendering/Pipeline/IShader.cs
@@ -8,9 +8,6 @@ namespace FinalEngine.Rendering.Pipeline
 
     public enum PipelineTarget
     {
-        // TODO: Should this even be here, I only did it to satisfy unit tests?
-        None,
-
         Vertex,
 
         Fragment,

--- a/FinalEngine.Tests/Rendering/Buffers/InputElementTests.cs
+++ b/FinalEngine.Tests/Rendering/Buffers/InputElementTests.cs
@@ -4,9 +4,11 @@
 
 namespace FinalEngine.Tests.Rendering.Buffers
 {
+    using System.Diagnostics.CodeAnalysis;
     using FinalEngine.Rendering.Buffers;
     using NUnit.Framework;
 
+    [ExcludeFromCodeCoverage]
     public class InputElementTests
     {
         private InputElement element;
@@ -54,6 +56,7 @@ namespace FinalEngine.Tests.Rendering.Buffers
         [SetUp]
         public void Setup()
         {
+            // Arrange
             this.element = new InputElement(234, 432, InputElementType.Float, 304);
         }
     }

--- a/FinalEngine.Tests/Rendering/Buffers/InputElementTests.cs
+++ b/FinalEngine.Tests/Rendering/Buffers/InputElementTests.cs
@@ -11,6 +11,14 @@ namespace FinalEngine.Tests.Rendering.Buffers
     [ExcludeFromCodeCoverage]
     public class InputElementTests
     {
+        private const int Index = 234;
+
+        private const int RelativeOffset = 304;
+
+        private const int Size = 432;
+
+        private const InputElementType Type = InputElementType.Float;
+
         private InputElement element;
 
         [Test]
@@ -20,7 +28,7 @@ namespace FinalEngine.Tests.Rendering.Buffers
             int actual = this.element.Index;
 
             // Assert
-            Assert.AreEqual(234, actual);
+            Assert.AreEqual(Index, actual);
         }
 
         [Test]
@@ -30,7 +38,7 @@ namespace FinalEngine.Tests.Rendering.Buffers
             int actual = this.element.RelativeOffset;
 
             // Assert
-            Assert.AreEqual(304, actual);
+            Assert.AreEqual(RelativeOffset, actual);
         }
 
         [Test]
@@ -40,7 +48,7 @@ namespace FinalEngine.Tests.Rendering.Buffers
             int actual = this.element.Size;
 
             // Assert
-            Assert.AreEqual(432, actual);
+            Assert.AreEqual(Size, actual);
         }
 
         [Test]
@@ -50,14 +58,14 @@ namespace FinalEngine.Tests.Rendering.Buffers
             InputElementType actual = this.element.Type;
 
             // Assert
-            Assert.AreEqual(InputElementType.Float, actual);
+            Assert.AreEqual(Type, actual);
         }
 
         [SetUp]
         public void Setup()
         {
             // Arrange
-            this.element = new InputElement(234, 432, InputElementType.Float, 304);
+            this.element = new InputElement(Index, Size, Type, RelativeOffset);
         }
     }
 }

--- a/FinalEngine.Tests/Rendering/Buffers/InputElementTests.cs
+++ b/FinalEngine.Tests/Rendering/Buffers/InputElementTests.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="InputElementTests.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Rendering.Buffers
+{
+    using FinalEngine.Rendering.Buffers;
+    using NUnit.Framework;
+
+    public class InputElementTests
+    {
+        private InputElement element;
+
+        [Test]
+        public void ConstructorShouldSetIndexToParameterWhenInvoked()
+        {
+            // Act
+            int actual = this.element.Index;
+
+            // Assert
+            Assert.AreEqual(234, actual);
+        }
+
+        [Test]
+        public void ConstructorShouldSetRelativeOffsetToParameterWhenInvoked()
+        {
+            // Act
+            int actual = this.element.RelativeOffset;
+
+            // Assert
+            Assert.AreEqual(304, actual);
+        }
+
+        [Test]
+        public void ConstructorShouldSetSizeToParameterWhenInvoked()
+        {
+            // Act
+            int actual = this.element.Size;
+
+            // Assert
+            Assert.AreEqual(432, actual);
+        }
+
+        [Test]
+        public void ConstructorShouldSetTypeToParameterWhenInvoked()
+        {
+            // Act
+            InputElementType actual = this.element.Type;
+
+            // Assert
+            Assert.AreEqual(InputElementType.Float, actual);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            this.element = new InputElement(234, 432, InputElementType.Float, 304);
+        }
+    }
+}

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -13,6 +13,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
     using OpenTK.Graphics.OpenGL4;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "This is done in TearDown.")]
     public class OpenGLIndexBufferTests
     {
         private int[] data;

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -84,6 +84,16 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
+        public void DisposeShouldInvokeDeleteBufferWhenInvoked()
+        {
+            // Act
+            this.indexBuffer.Dispose();
+
+            // Assert
+            this.invoker.Verify(x => x.DeleteBuffer(this.id), Times.Once);
+        }
+
+        [Test]
         public void LengthShouldReturnSameAsConstructorInputWhenInvoked()
         {
             // Act
@@ -114,9 +124,6 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         [TearDown]
         public void Teardown()
         {
-            this.indexBuffer.Dispose();
-
-            // One more time, just to be safe.
             this.indexBuffer.Dispose();
         }
     }

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -16,15 +16,13 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
     [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "This is done in TearDown.")]
     public class OpenGLIndexBufferTests
     {
-        private int[] data;
+        private const int ID = 306;
 
-        private int id;
+        private readonly int[] data = { 3, 5, 7, 1, 3, 6, 7, 1, 5, 3, };
 
         private OpenGLIndexBuffer<int> indexBuffer;
 
         private Mock<IOpenGLInvoker> invoker;
-
-        private int length;
 
         [Test]
         public void BindShouldInvokeBindBufferIDWhenIndexBufferIsNotDisposed()
@@ -36,7 +34,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             this.indexBuffer.Bind();
 
             // Assert
-            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, this.id), Times.Once);
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, ID), Times.Once);
         }
 
         [Test]
@@ -53,7 +51,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         public void ConstructorShouldInvokeBindBufferIDWhenParametersAreNotNull()
         {
             // Assert
-            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, this.id), Times.Once);
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, ID), Times.Once);
         }
 
         [Test]
@@ -91,7 +89,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             this.indexBuffer.Dispose();
 
             // Assert
-            this.invoker.Verify(x => x.DeleteBuffer(this.id), Times.Once);
+            this.invoker.Verify(x => x.DeleteBuffer(ID), Times.Once);
         }
 
         [Test]
@@ -101,24 +99,15 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             int actual = this.indexBuffer.Length;
 
             // Assert
-            Assert.AreEqual(this.length, actual);
+            Assert.AreEqual(this.data.Length, actual);
         }
 
         [SetUp]
         public void Setup()
         {
             // Arrange
-            this.id = 306;
-
             this.invoker = new Mock<IOpenGLInvoker>();
-            this.invoker.Setup(x => x.GenBuffer()).Returns(this.id);
-
-            this.data = new int[]
-            {
-                3, 5, 7, 1, 3, 6, 7, 1, 5, 3,
-            };
-
-            this.length = this.data.Length;
+            this.invoker.Setup(x => x.GenBuffer()).Returns(ID);
 
             this.indexBuffer = new OpenGLIndexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int));
         }

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -1,0 +1,120 @@
+﻿// <copyright file="OpenGLIndexBufferTests.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using FinalEngine.Rendering.OpenGL.Buffers;
+    using FinalEngine.Rendering.OpenGL.Invocation;
+    using Moq;
+    using NUnit.Framework;
+    using OpenTK.Graphics.OpenGL4;
+
+    [ExcludeFromCodeCoverage]
+    public class OpenGLIndexBufferTests
+    {
+        private int[] data;
+
+        private int id;
+
+        private OpenGLIndexBuffer<int> indexBuffer;
+
+        private Mock<IOpenGLInvoker> invoker;
+
+        private int length;
+
+        [Test]
+        public void BindShouldInvokeBindBufferIDWhenIndexBufferIsNotDisposed()
+        {
+            // Act
+            this.indexBuffer.Bind();
+
+            // Assert
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, this.id), Times.Once);
+        }
+
+        [Test]
+        public void BindShouldThrowObjectDisposedExceptionWhenIndexBufferIsDisposed()
+        {
+            // Arrange
+            this.indexBuffer.Dispose();
+
+            // Act and assert
+            Assert.Throws<ObjectDisposedException>(() => this.indexBuffer.Bind());
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeBindBufferIDWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, this.id), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeBindBufferZeroWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, 0), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeGenBufferWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.GenBuffer(), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenDataIsNull()
+        {
+            // Arrange, act and assert
+            Assert.Throws<ArgumentNullException>(() => new OpenGLIndexBuffer<int>(new Mock<IOpenGLInvoker>().Object, null, 0));
+        }
+
+        [Test]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsnull()
+        {
+            // Arrange, act and assert
+            Assert.Throws<ArgumentNullException>(() => new OpenGLIndexBuffer<int>(null, Array.Empty<int>(), 0));
+        }
+
+        [Test]
+        public void LengthShouldReturnSameAsConstructorInputWhenInvoked()
+        {
+            // Act
+            int actual = this.indexBuffer.Length;
+
+            // Assert
+            Assert.AreEqual(this.length, actual);
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            this.id = 306;
+
+            this.invoker = new Mock<IOpenGLInvoker>();
+            this.invoker.Setup(x => x.GenBuffer()).Returns(this.id);
+
+            this.data = new int[]
+            {
+                3, 5, 7, 1, 3, 6, 7, 1, 5, 3,
+            };
+
+            this.length = this.data.Length;
+
+            this.indexBuffer = new OpenGLIndexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int));
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.indexBuffer.Dispose();
+
+            // One more time, just to be safe.
+            this.indexBuffer.Dispose();
+        }
+    }
+}

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -28,6 +28,9 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         [Test]
         public void BindShouldInvokeBindBufferIDWhenIndexBufferIsNotDisposed()
         {
+            // Arrange
+            this.invoker.Reset();
+
             // Act
             this.indexBuffer.Bind();
 

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -78,7 +78,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
-        public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsnull()
+        public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsNull()
         {
             // Arrange, act and assert
             Assert.Throws<ArgumentNullException>(() => new OpenGLIndexBuffer<int>(null, Array.Empty<int>(), 0));
@@ -107,6 +107,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         [SetUp]
         public void Setup()
         {
+            // Arrange
             this.id = 306;
 
             this.invoker = new Mock<IOpenGLInvoker>();

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
@@ -18,7 +18,14 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
     [ExcludeFromCodeCoverage]
     public class OpenGLInputLayoutTests
     {
-        private List<InputElement> elements;
+        private readonly List<InputElement> elements = new List<InputElement>()
+        {
+            new InputElement(0, 3, InputElementType.Float, 0),
+            new InputElement(1, 4, InputElementType.Byte, 12),
+            new InputElement(2, 3, InputElementType.Short, 28),
+            new InputElement(3, 3, InputElementType.Double, 22),
+            new InputElement(4, 5, InputElementType.Int, 121),
+        };
 
         private OpenGLInputLayout inputLayout;
 
@@ -98,16 +105,6 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         {
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
-
-            this.elements = new List<InputElement>()
-            {
-                new InputElement(0, 3, InputElementType.Float, 0),
-                new InputElement(1, 4, InputElementType.Byte, 12),
-                new InputElement(2, 3, InputElementType.Short, 28),
-                new InputElement(3, 3, InputElementType.Double, 22),
-                new InputElement(4, 5, InputElementType.Int, 121),
-            };
-
             this.inputLayout = new OpenGLInputLayout(this.invoker.Object, this.elements);
         }
     }

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
@@ -96,6 +96,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         [SetUp]
         public void Setup()
         {
+            // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
 
             this.elements = new List<InputElement>()

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
@@ -1,0 +1,103 @@
+﻿// <copyright file="OpenGLInputLayoutTests.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using FinalEngine.Rendering.Buffers;
+    using FinalEngine.Rendering.OpenGL.Buffers;
+    using FinalEngine.Rendering.OpenGL.Invocation;
+    using Moq;
+    using NUnit.Framework;
+    using OpenTK.Graphics.OpenGL4;
+
+    [ExcludeFromCodeCoverage]
+    public class OpenGLInputLayoutTests
+    {
+        private List<InputElement> elements;
+
+        private OpenGLInputLayout inputLayout;
+
+        private Mock<IOpenGLInvoker> invoker;
+
+        [Test]
+        public void BindShouldInvokeEnableVertexAttribArrayWhenInvoked()
+        {
+            // Act
+            this.inputLayout.Bind();
+
+            // Assert
+            this.invoker.Verify(x => x.EnableVertexAttribArray(It.IsAny<int>()), Times.Exactly(this.elements.Count));
+        }
+
+        [Test]
+        public void BindShouldInvokeVertexAttribBindingWhenInvoked()
+        {
+            // Act
+            this.inputLayout.Bind();
+
+            // Assert
+            this.invoker.Verify(x => x.VertexAttribBinding(It.IsAny<int>(), It.IsAny<int>()), Times.Exactly(this.elements.Count));
+        }
+
+        [Test]
+        public void BindShouldInvokeVertexAttribFormatWhenInvoked()
+        {
+            // Act
+            this.inputLayout.Bind();
+
+            // Assert
+            this.invoker.Verify(x => x.VertexAttribFormat(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<VertexAttribType>(), false, It.IsAny<int>()), Times.Exactly(this.elements.Count));
+        }
+
+        [Test]
+        public void BindShouldThrowNotSupportedExceptionWhenInvalidEnumIsParameter()
+        {
+            // Arrange
+            Assert.IsFalse(Enum.IsDefined(typeof(InputElementType), int.MaxValue));
+
+            this.elements.Add(new InputElement()
+            {
+                Type = (InputElementType)int.MaxValue,
+            });
+
+            // Act and assert
+            Assert.Throws<NotSupportedException>(() => this.inputLayout.Bind());
+        }
+
+        [Test]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenElementsIsNull()
+        {
+            // Arrange, act and assert
+            Assert.Throws<ArgumentNullException>(() => new OpenGLInputLayout(new Mock<IOpenGLInvoker>().Object, null));
+        }
+
+        [Test]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsNull()
+        {
+            // Arrange, act and assert
+            Assert.Throws<ArgumentNullException>(() => new OpenGLInputLayout(null, Enumerable.Empty<InputElement>()));
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            this.invoker = new Mock<IOpenGLInvoker>();
+
+            this.elements = new List<InputElement>()
+            {
+                new InputElement(0, 3, InputElementType.Float, 0),
+                new InputElement(1, 4, InputElementType.Byte, 12),
+                new InputElement(2, 3, InputElementType.Short, 28),
+                new InputElement(3, 3, InputElementType.Double, 22),
+                new InputElement(4, 5, InputElementType.Int, 121),
+            };
+
+            this.inputLayout = new OpenGLInputLayout(this.invoker.Object, this.elements);
+        }
+    }
+}

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLInputLayoutTests.cs
@@ -83,6 +83,16 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             Assert.Throws<ArgumentNullException>(() => new OpenGLInputLayout(null, Enumerable.Empty<InputElement>()));
         }
 
+        [Test]
+        public void ResetShouldInvokeDisableVertexAttribArrayWhenInvoked()
+        {
+            // Act
+            this.inputLayout.Reset();
+
+            // Assert
+            this.invoker.Verify(x => x.DisableVertexAttribArray(It.IsAny<int>()), Times.Exactly(this.elements.Count));
+        }
+
         [SetUp]
         public void Setup()
         {

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -16,9 +16,11 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
     [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "This is done in TearDown.")]
     public class OpenGLVertexBufferTests
     {
-        private int[] data;
+        private const int ID = 42;
 
-        private int id;
+        private const int Stride = 32;
+
+        private readonly int[] data = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
 
         private Mock<IOpenGLInvoker> invoker;
 
@@ -31,7 +33,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             this.vertexBuffer.Bind();
 
             // Assert
-            this.invoker.Verify(x => x.BindVertexBuffer(0, this.id, IntPtr.Zero, this.vertexBuffer.Stride), Times.Once);
+            this.invoker.Verify(x => x.BindVertexBuffer(0, ID, IntPtr.Zero, this.vertexBuffer.Stride), Times.Once);
         }
 
         [Test]
@@ -48,7 +50,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         public void ConstructorShouldInvokeBindBufferIDWhenParametersAreNotNull()
         {
             // Assert
-            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, this.id), Times.Once);
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, ID), Times.Once);
         }
 
         [Test]
@@ -93,24 +95,16 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             this.vertexBuffer.Dispose();
 
             // Assert
-            this.invoker.Verify(x => x.DeleteBuffer(this.id), Times.Once);
+            this.invoker.Verify(x => x.DeleteBuffer(ID), Times.Once);
         }
 
         [SetUp]
         public void Setup()
         {
-            // Arrange
-            this.id = 42;
-
             this.invoker = new Mock<IOpenGLInvoker>();
-            this.invoker.Setup(x => x.GenBuffer()).Returns(this.id);
+            this.invoker.Setup(x => x.GenBuffer()).Returns(ID);
 
-            this.data = new int[]
-            {
-                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
-            };
-
-            this.vertexBuffer = new OpenGLVertexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int), 1);
+            this.vertexBuffer = new OpenGLVertexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int), Stride);
         }
 
         [Test]
@@ -120,7 +114,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             int actual = this.vertexBuffer.Stride;
 
             // Assert
-            Assert.AreEqual(1, actual);
+            Assert.AreEqual(Stride, actual);
         }
 
         [TearDown]

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -61,7 +61,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         public void ConstructorShouldInvokeBufferDataWhenParametersAreNotNulL()
         {
             // Assert
-            this.invoker.Verify(x => x.BufferData<int>(BufferTarget.ArrayBuffer, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
+            this.invoker.Verify(x => x.BufferData(BufferTarget.ArrayBuffer, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
         }
 
         [Test]

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -99,6 +99,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         [SetUp]
         public void Setup()
         {
+            // Arrange
             this.id = 42;
 
             this.invoker = new Mock<IOpenGLInvoker>();

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -24,7 +24,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         private OpenGLVertexBuffer<int> vertexBuffer;
 
         [Test]
-        public void BindShouldInvokeBindVertexBufferWhenVertexBufferIsNotDisposed()
+        public void BindShouldInvokeBindVertexBufferIDWhenVertexBufferIsNotDisposed()
         {
             // Act
             this.vertexBuffer.Bind();
@@ -51,7 +51,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
-        public void ConstructorShouldInvokeBindBufferNoneWhenParametersAreNotNull()
+        public void ConstructorShouldInvokeBindBufferZeroWhenParametersAreNotNull()
         {
             // Assert
             this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, 0), Times.Once);

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -44,7 +44,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
-        public void ConstructorShouldInvokeBindBufferIdentifierWhenParametersAreNotNull()
+        public void ConstructorShouldInvokeBindBufferIDWhenParametersAreNotNull()
         {
             // Assert
             this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, this.id), Times.Once);

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -85,6 +85,16 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(null, Array.Empty<int>(), 0, 0));
         }
 
+        [Test]
+        public void DisposeShouldInvokeDeleteBufferWhenInvoked()
+        {
+            // Act
+            this.vertexBuffer.Dispose();
+
+            // Assert
+            this.invoker.Verify(x => x.DeleteBuffer(this.id), Times.Once);
+        }
+
         [SetUp]
         public void Setup()
         {
@@ -111,12 +121,9 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             Assert.AreEqual(1, actual);
         }
 
-        [Test]
+        [TearDown]
         public void Teardown()
         {
-            this.vertexBuffer.Dispose();
-
-            // Dispose once more just to be safe.
             this.vertexBuffer.Dispose();
         }
     }

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -13,6 +13,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
     using OpenTK.Graphics.OpenGL4;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "This is done in TearDown.")]
     public class OpenGLVertexBufferTests
     {
         private int[] data;

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -1,0 +1,123 @@
+﻿// <copyright file="OpenGLVertexBufferTests.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using FinalEngine.Rendering.OpenGL.Buffers;
+    using FinalEngine.Rendering.OpenGL.Invocation;
+    using Moq;
+    using NUnit.Framework;
+    using OpenTK.Graphics.OpenGL4;
+
+    [ExcludeFromCodeCoverage]
+    public class OpenGLVertexBufferTests
+    {
+        private int[] data;
+
+        private int id;
+
+        private Mock<IOpenGLInvoker> invoker;
+
+        private OpenGLVertexBuffer<int> vertexBuffer;
+
+        [Test]
+        public void BindShouldInvokeBindVertexBufferWhenVertexBufferIsNotDisposed()
+        {
+            // Act
+            this.vertexBuffer.Bind();
+
+            // Assert
+            this.invoker.Verify(x => x.BindVertexBuffer(0, this.id, IntPtr.Zero, this.vertexBuffer.Stride), Times.Once);
+        }
+
+        [Test]
+        public void BindShouldThrowObjectDisposedExceptionWhenVertexBufferIsDisposed()
+        {
+            // Arrange
+            this.vertexBuffer.Dispose();
+
+            // Act and assert
+            Assert.Throws<ObjectDisposedException>(() => this.vertexBuffer.Bind());
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeBindBufferIdentifierWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, this.id), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeBindBufferNoneWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, 0), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeBufferDataWhenParametersAreNotNulL()
+        {
+            // Assert
+            this.invoker.Verify(x => x.BufferData<int>(BufferTarget.ArrayBuffer, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeGenBufferWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.GenBuffer(), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenDataIsNull()
+        {
+            // Arrange, act and assert
+            Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(new Mock<IOpenGLInvoker>().Object, null, 0, 0));
+        }
+
+        [Test]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsNull()
+        {
+            // Arrange, act and assert
+            Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(null, Array.Empty<int>(), 0, 0));
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            this.id = 42;
+
+            this.invoker = new Mock<IOpenGLInvoker>();
+            this.invoker.Setup(x => x.GenBuffer()).Returns(this.id);
+
+            this.data = new int[]
+            {
+                0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+            };
+
+            this.vertexBuffer = new OpenGLVertexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int), 1);
+        }
+
+        [Test]
+        public void StrideShouldReturnSameAsConstructorInputWhenInvoked()
+        {
+            // Act
+            int actual = this.vertexBuffer.Stride;
+
+            // Assert
+            Assert.AreEqual(1, actual);
+        }
+
+        [Test]
+        public void Teardown()
+        {
+            this.vertexBuffer.Dispose();
+
+            // Dispose once more just to be safe.
+            this.vertexBuffer.Dispose();
+        }
+    }
+}

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLGPUResourceFactoryTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLGPUResourceFactoryTests.cs
@@ -7,7 +7,10 @@ namespace FinalEngine.Tests.Rendering.OpenGL
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using FinalEngine.Rendering.Buffers;
     using FinalEngine.Rendering.OpenGL;
+    using FinalEngine.Rendering.OpenGL.Buffers;
     using FinalEngine.Rendering.OpenGL.Invocation;
     using FinalEngine.Rendering.OpenGL.Pipeline;
     using FinalEngine.Rendering.Pipeline;
@@ -26,6 +29,40 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         {
             // Arrange, act and assert
             Assert.Throws<ArgumentNullException>(() => new OpenGLGPUResourceFactory(null));
+        }
+
+        [Test]
+        public void CreateIndexBufferShouldReturnOpenGLIndexBufferWhenDataIsNotNull()
+        {
+            // Act
+            IIndexBuffer actual = this.factory.CreateIndexBuffer(Array.Empty<int>(), 0);
+
+            // Assert
+            Assert.IsInstanceOf(typeof(OpenGLIndexBuffer<int>), actual);
+        }
+
+        [Test]
+        public void CreateIndexBufferShouldThrowArgumentNullExceptionWhenDataIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.factory.CreateIndexBuffer<int>(null, 0));
+        }
+
+        [Test]
+        public void CreateInputLayoutShouldReturnOpenGLInputLayoutWhenElementsIsNotNull()
+        {
+            // Act
+            IInputLayout actual = this.factory.CreateInputLayout(Enumerable.Empty<InputElement>());
+
+            // Assert
+            Assert.IsNotInstanceOf(typeof(InputElement), actual);
+        }
+
+        [Test]
+        public void CreateInputLayoutShouldThrowArgumentNullExceptionWhenElementsIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.factory.CreateInputLayout(null));
         }
 
         [Test]
@@ -94,6 +131,23 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         {
             // Act and assert
             Assert.Throws<ArgumentNullException>(() => this.factory.CreateShader(PipelineTarget.Vertex, "\t\r\n"));
+        }
+
+        [Test]
+        public void CreateVertexBufferShouldReturnOpenGLVertexBufferWhenDataIsNotNull()
+        {
+            // Act
+            IVertexBuffer actual = this.factory.CreateVertexBuffer(Array.Empty<int>(), 0, 0);
+
+            // Assert
+            Assert.IsInstanceOf(typeof(OpenGLVertexBuffer<int>), actual);
+        }
+
+        [Test]
+        public void CreateVertexBufferShouldThrowArgumentNullExceptionWhenDataIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.factory.CreateVertexBuffer<int>(null, 0, 0));
         }
 
         [SetUp]

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLGPUResourceFactoryTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLGPUResourceFactoryTests.cs
@@ -55,7 +55,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
             IInputLayout actual = this.factory.CreateInputLayout(Enumerable.Empty<InputElement>());
 
             // Assert
-            Assert.IsNotInstanceOf(typeof(InputElement), actual);
+            Assert.IsInstanceOf(typeof(OpenGLInputLayout), actual);
         }
 
         [Test]

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
@@ -58,6 +58,20 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         }
 
         [Test]
+        public void SetInputLayoutShouldInvokeResetWhenSetInputLayoutPreviouslyCalled()
+        {
+            // Arrange
+            var layout = new Mock<IOpenGLInputLayout>();
+            this.inputAssembler.SetInputLayout(layout.Object);
+
+            // Act
+            this.inputAssembler.SetInputLayout(layout.Object);
+
+            // Assert
+            layout.Verify(x => x.Reset(), Times.Once);
+        }
+
+        [Test]
         public void SetInputLayoutShouldThrowArgumentExceptionWhenBufferIsNotOpenGLInputLayout()
         {
             // Act and assert

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
@@ -1,0 +1,107 @@
+﻿// <copyright file="OpenGLInputAssemblerTests.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Rendering.OpenGL
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+    using FinalEngine.Rendering.Buffers;
+    using FinalEngine.Rendering.OpenGL;
+    using FinalEngine.Rendering.OpenGL.Buffers;
+    using Moq;
+    using NUnit.Framework;
+
+    [ExcludeFromCodeCoverage]
+    public class OpenGLInputAssemblerTests
+    {
+        private OpenGLInputAssembler inputAssembler;
+
+        [Test]
+        public void SetIndexBufferShouldInvokeBindWhenBufferIsOpenGLIndexBuffer()
+        {
+            // Arrange
+            var buffer = new Mock<IOpenGLIndexBuffer>();
+
+            // Act
+            this.inputAssembler.SetIndexBuffer(buffer.Object);
+
+            // Assert
+            buffer.Verify(x => x.Bind(), Times.Once);
+        }
+
+        [Test]
+        public void SetIndexBufferShouldThrowArgumentExceptionWhenBufferIsNotOpenGLIndexBuffer()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentException>(() => this.inputAssembler.SetIndexBuffer(new Mock<IIndexBuffer>().Object));
+        }
+
+        [Test]
+        public void SetIndexBufferShouldThrowArgumentNullExceptionWhenBufferIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.inputAssembler.SetIndexBuffer(null));
+        }
+
+        [Test]
+        public void SetInputLayoutShouldInvokeBindWhenBufferIsOpenGLInputLayout()
+        {
+            // Arrange
+            var layout = new Mock<IOpenGLInputLayout>();
+
+            // Act
+            this.inputAssembler.SetInputLayout(layout.Object);
+
+            // Assert
+            layout.Verify(x => x.Bind(), Times.Once);
+        }
+
+        [Test]
+        public void SetInputLayoutShouldThrowArgumentExceptionWhenBufferIsNotOpenGLInputLayout()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentException>(() => this.inputAssembler.SetInputLayout(new Mock<IInputLayout>().Object));
+        }
+
+        [Test]
+        public void SetInputLayoutShouldThrowArgumentNullExceptionWhenBufferIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.inputAssembler.SetInputLayout(null));
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            this.inputAssembler = new OpenGLInputAssembler();
+        }
+
+        [Test]
+        public void SetVertexBufferShouldInvokeBindWhenBufferIsOpenGLVertexBuffer()
+        {
+            // Arrange
+            var buffer = new Mock<IOpenGLVertexBuffer>();
+
+            // Act
+            this.inputAssembler.SetVertexBuffer(buffer.Object);
+
+            // Assert
+            buffer.Verify(x => x.Bind(), Times.Once);
+        }
+
+        [Test]
+        public void SetVertexBufferShouldThrowArgumentExceptionWhenBufferIsNotOpenGLVertexBuffer()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentException>(() => this.inputAssembler.SetVertexBuffer(new Mock<IVertexBuffer>().Object));
+        }
+
+        [Test]
+        public void SetVertexBufferShouldThrowArgumentNullExceptionWhenBufferIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.inputAssembler.SetVertexBuffer(null));
+        }
+    }
+}

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
@@ -45,7 +45,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         }
 
         [Test]
-        public void SetInputLayoutShouldInvokeBindWhenBufferIsOpenGLInputLayout()
+        public void SetInputLayoutShouldInvokeBindWhenLayoutIsOpenGLInputLayout()
         {
             // Arrange
             var layout = new Mock<IOpenGLInputLayout>();
@@ -88,6 +88,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         [SetUp]
         public void Setup()
         {
+            // Arrange
             this.inputAssembler = new OpenGLInputAssembler();
         }
 

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
@@ -14,6 +14,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
     using OpenTK.Windowing.Common;
 
     [ExcludeFromCodeCoverage]
+    [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "This is done in TearDown.")]
     public class OpenGLRenderContextTests
     {
         private Mock<IBindingsContext> bindings;

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
@@ -17,6 +17,8 @@ namespace FinalEngine.Tests.Rendering.OpenGL
     [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "This is done in TearDown.")]
     public class OpenGLRenderContextTests
     {
+        private const int ID = 10;
+
         private Mock<IBindingsContext> bindings;
 
         private Mock<IGraphicsContext> context;
@@ -29,7 +31,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         public void ConstructorShouldInvokeBindVertexArrayWhenParametersAreNotNull()
         {
             // Assert
-            this.invoker.Verify(x => x.BindVertexArray(10), Times.Once);
+            this.invoker.Verify(x => x.BindVertexArray(ID), Times.Once);
         }
 
         [Test]
@@ -97,7 +99,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
 
-            this.invoker.Setup(x => x.GenVertexArray()).Returns(10);
+            this.invoker.Setup(x => x.GenVertexArray()).Returns(ID);
 
             this.bindings = new Mock<IBindingsContext>();
             this.context = new Mock<IGraphicsContext>();

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
@@ -25,10 +25,24 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         private OpenGLRenderContext renderContext;
 
         [Test]
+        public void ConstructorShouldInvokeBindVertexArrayWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.BindVertexArray(10), Times.Once);
+        }
+
+        [Test]
         public void ConstructorShouldInvokeContextMakeCurrentWhenParametersAreNotNull()
         {
             // Assert
             this.context.Verify(x => x.MakeCurrent(), Times.Once);
+        }
+
+        [Test]
+        public void ConstructorShouldInvokeGenVertexArrayWhenParametersAreNotNull()
+        {
+            // Assert
+            this.invoker.Verify(x => x.GenVertexArray(), Times.Once);
         }
 
         [Test]
@@ -66,11 +80,24 @@ namespace FinalEngine.Tests.Rendering.OpenGL
             Assert.Throws<ArgumentNullException>(() => new OpenGLRenderContext(null, new Mock<IBindingsContext>().Object, new Mock<IGraphicsContext>().Object));
         }
 
+        [Test]
+        public void DisposeShouldInvokeDeleteVertexArrayWhenInvoked()
+        {
+            // Act
+            this.renderContext.Dispose();
+
+            // Assert
+            this.invoker.Verify(x => x.DeleteVertexArray(10), Times.Once);
+        }
+
         [SetUp]
         public void Setup()
         {
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
+
+            this.invoker.Setup(x => x.GenVertexArray()).Returns(10);
+
             this.bindings = new Mock<IBindingsContext>();
             this.context = new Mock<IGraphicsContext>();
             this.renderContext = new OpenGLRenderContext(this.invoker.Object, this.bindings.Object, this.context.Object);
@@ -100,6 +127,12 @@ namespace FinalEngine.Tests.Rendering.OpenGL
 
             // Assert
             this.context.Verify(x => x.SwapBuffers(), Times.Never);
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+            this.renderContext.Dispose();
         }
     }
 }

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
@@ -47,7 +47,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         }
 
         [Test]
-        public void ConstructorShouldInvokeInvokeLoadBindingsWhenParametersAreNotNull()
+        public void ConstructorShouldInvokeLoadBindingsWhenParametersAreNotNull()
         {
             // Assert
             this.invoker.Verify(x => x.LoadBindings(this.bindings.Object), Times.Once);

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderDeviceTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderDeviceTests.cs
@@ -122,6 +122,16 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         }
 
         [Test]
+        public void InputAssemblerShouldReturnOpenGLInputAssembler()
+        {
+            // Act
+            IInputAssembler actual = this.renderDevice.InputAssembler;
+
+            // Assert
+            Assert.IsInstanceOf(typeof(OpenGLInputAssembler), actual);
+        }
+
+        [Test]
         public void PipelineShouldReturnOpenGLPipeline()
         {
             // Act

--- a/FinalEngine.Tests/Rendering/OpenGL/Pipeline/OpenGLShaderTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Pipeline/OpenGLShaderTests.cs
@@ -114,7 +114,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Pipeline
         }
 
         [Test]
-        public void ConstructorShouldThrowNotSupportedExceptionWhenShaderTypeIsNone()
+        public void ConstructorShouldThrowNotSupportedExceptionWhenShaderTypeIsNotDefined()
         {
             // Arrange
             Assert.IsFalse(Enum.IsDefined(typeof(PipelineTarget), int.MaxValue));

--- a/FinalEngine.Tests/Rendering/OpenGL/Pipeline/OpenGLShaderTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Pipeline/OpenGLShaderTests.cs
@@ -117,10 +117,12 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Pipeline
         public void ConstructorShouldThrowNotSupportedExceptionWhenShaderTypeIsNone()
         {
             // Arrange
+            Assert.IsFalse(Enum.IsDefined(typeof(PipelineTarget), int.MaxValue));
+
             var invoker = new Mock<IOpenGLInvoker>();
 
             // Act and assert
-            Assert.Throws<NotSupportedException>(() => new OpenGLShader(invoker.Object, PipelineTarget.None, "test"));
+            Assert.Throws<NotSupportedException>(() => new OpenGLShader(invoker.Object, (PipelineTarget)int.MaxValue, "test"));
         }
 
         [Test]

--- a/Goal.txt
+++ b/Goal.txt
@@ -4,16 +4,16 @@
   - Render Context
   - Render Device
     - Input Assembler
-    - Rasterizer
-    - Pipeline
+    - Rasterizer :)
+    - Pipeline :)
     - Output Merger
     - Resource Factory
       - Render Target 2D
       - Texture 2D
-      - Vertex Buffer
+      - Vertex Buffer :)
       - Input Layout
-      - Shader
-      - Shader Program
+      - Shader :)
+      - Shader Program :)
   - Mesh
   - Material
 - Audio

--- a/Goal.txt
+++ b/Goal.txt
@@ -3,7 +3,7 @@
 - Rendering
   - Render Context
   - Render Device
-    - Input Assembler
+    - Input Assembler :)
     - Rasterizer :)
     - Pipeline :)
     - Output Merger
@@ -11,7 +11,7 @@
       - Render Target 2D
       - Texture 2D
       - Vertex Buffer :)
-      - Input Layout
+      - Input Layout :)
       - Shader :)
       - Shader Program :)
   - Mesh

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -4,6 +4,8 @@
 
 namespace TestGame
 {
+    //// TODO: Make sure that all OpenGL unit tests are checking whether the delete calls are being invoked inside their Dispose methods.
+
     using System;
     using System.Collections.Generic;
     using System.Drawing;

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -8,6 +8,7 @@ namespace TestGame
     using System.Collections.Generic;
     using System.Drawing;
     using System.IO;
+    using System.Runtime.InteropServices;
     using FinalEngine.Input.Keyboard;
     using FinalEngine.Input.Mouse;
     using FinalEngine.IO;
@@ -15,14 +16,42 @@ namespace TestGame
     using FinalEngine.Platform.Desktop.OpenTK;
     using FinalEngine.Platform.Desktop.OpenTK.Invocation;
     using FinalEngine.Rendering;
+    using FinalEngine.Rendering.Buffers;
     using FinalEngine.Rendering.OpenGL;
     using FinalEngine.Rendering.OpenGL.Invocation;
     using FinalEngine.Rendering.Pipeline;
-    using OpenTK.Graphics.OpenGL4;
     using OpenTK.Mathematics;
     using OpenTK.Windowing.Common;
     using OpenTK.Windowing.Desktop;
     using OpenTK.Windowing.GraphicsLibraryFramework;
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct Vertex
+    {
+        public static readonly int SizeInBytes = Marshal.SizeOf<Vertex>();
+
+        [FieldOffset(0)]
+        private Vector3 position;
+
+        [FieldOffset(12)]
+        private Vector4 color;
+
+        public Vertex(Vector3 position, Vector4 color)
+        {
+            this.position = position;
+            this.color = color;
+        }
+
+        public Vector3 Position
+        {
+            get { return this.position; }
+        }
+
+        public Vector4 Color
+        {
+            get { return this.color; }
+        }
+    }
 
     /// <summary>
     ///   The main program.
@@ -74,6 +103,8 @@ namespace TestGame
 
             IRasterizer rasterizer = renderDevice.Rasterizer;
             IPipeline pipeline = renderDevice.Pipeline;
+            IInputAssembler inputAssembler = renderDevice.InputAssembler;
+
             IGPUResourceFactory factory = renderDevice.Factory;
 
             rasterizer.SetRasterState(default);
@@ -87,11 +118,18 @@ namespace TestGame
             IShaderProgram program = factory.CreateShaderProgram(shaders);
             pipeline.SetShaderProgram(program);
 
-            float[] vertices =
+            Vertex[] vertices =
             {
-                -0.5f, -0.5f, 0.0f, 1.0f, 0.0f, 0.0f, 1.0f,
-                0.5f, -0.5f, 0.0f, 0.0f, 1.0f, 0.0f, 1.0f,
-                0.0f,  0.5f, 0.0f, 0.0f, 0.0f, 1.0f, 1.0f,
+                new Vertex(new Vector3(-0.9f, -0.5f, 0.0f), new Vector4(1.0f, 0.0f, 0.0f, 1.0f)),
+                new Vertex(new Vector3(-0.0f, -0.5f, 0.0f), new Vector4(0.0f, 1.0f, 0.0f, 1.0f)),
+                new Vertex(new Vector3(-0.45f, 0.5f, 0.0f), new Vector4(0.0f, 0.0f, 1.0f, 1.0f)),
+            };
+
+            Vertex[] vertices2 =
+            {
+                new Vertex(new Vector3(0.0f, -0.5f, 0.0f), new Vector4(1.0f, 1.0f, 0.0f, 1.0f)),
+                new Vertex(new Vector3(0.9f, -0.5f, 0.0f), new Vector4(0.0f, 1.0f, 1.0f, 1.0f)),
+                new Vertex(new Vector3(0.45f, 0.5f, 0.0f), new Vector4(1.0f, 0.0f, 1.0f, 1.0f)),
             };
 
             int[] indices =
@@ -99,23 +137,20 @@ namespace TestGame
                 0, 1, 2,
             };
 
-            int vao = GL.GenVertexArray();
-            int vbo = GL.GenBuffer();
-            int ebo = GL.GenBuffer();
+            var inputElements = new List<InputElement>()
+            {
+                new InputElement(0, 3, InputElementType.Float, Marshal.OffsetOf<Vertex>("position").ToInt32()),
+                new InputElement(1, 4, InputElementType.Float, Marshal.OffsetOf<Vertex>("color").ToInt32()),
+            };
 
-            GL.BindVertexArray(vao);
+            IInputLayout inputLayout = factory.CreateInputLayout(inputElements);
+            inputAssembler.SetInputLayout(inputLayout);
 
-            GL.BindBuffer(BufferTarget.ArrayBuffer, vbo);
-            GL.BufferData(BufferTarget.ArrayBuffer, vertices.Length * sizeof(float), vertices, BufferUsageHint.StaticDraw);
+            IVertexBuffer vertexBuffer = factory.CreateVertexBuffer(vertices, vertices.Length * Vertex.SizeInBytes, Vertex.SizeInBytes);
+            IVertexBuffer vertexBuffer2 = factory.CreateVertexBuffer(vertices2, vertices2.Length * Vertex.SizeInBytes, Vertex.SizeInBytes);
 
-            GL.VertexAttribPointer(0, 3, VertexAttribPointerType.Float, false, 7 * sizeof(float), 0);
-            GL.EnableVertexAttribArray(0);
-
-            GL.VertexAttribPointer(1, 4, VertexAttribPointerType.Float, false, 7 * sizeof(float), 3 * sizeof(float));
-            GL.EnableVertexAttribArray(1);
-
-            GL.BindBuffer(BufferTarget.ElementArrayBuffer, ebo);
-            GL.BufferData(BufferTarget.ElementArrayBuffer, indices.Length * sizeof(int), indices, BufferUsageHint.StaticDraw);
+            IIndexBuffer indexBuffer = factory.CreateIndexBuffer(indices, indices.Length * sizeof(int));
+            inputAssembler.SetIndexBuffer(indexBuffer);
 
             while (!window.IsExiting)
             {
@@ -123,15 +158,16 @@ namespace TestGame
                 mouse.Update();
 
                 renderDevice.Clear(Color.Black);
+
+                inputAssembler.SetVertexBuffer(vertexBuffer);
+                renderDevice.DrawIndices(PrimitiveTopology.Triangle, 0, indices.Length);
+
+                inputAssembler.SetVertexBuffer(vertexBuffer2);
                 renderDevice.DrawIndices(PrimitiveTopology.Triangle, 0, indices.Length);
 
                 renderContext.SwapBuffers();
                 window.ProcessEvents();
             }
-
-            GL.DeleteBuffer(ebo);
-            GL.DeleteBuffer(vbo);
-            GL.DeleteBuffer(vao);
 
             program.Dispose();
 
@@ -140,6 +176,7 @@ namespace TestGame
                 shader.Dispose();
             }
 
+            renderContext.Dispose();
             window.Dispose();
             nativeWindow.Dispose();
         }

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -4,12 +4,11 @@
 
 namespace TestGame
 {
-    //// TODO: Make sure that all OpenGL unit tests are checking whether the delete calls are being invoked inside their Dispose methods.
-
     using System;
     using System.Collections.Generic;
     using System.Drawing;
     using System.IO;
+    using System.Numerics;
     using System.Runtime.InteropServices;
     using FinalEngine.Input.Keyboard;
     using FinalEngine.Input.Mouse;
@@ -22,47 +21,12 @@ namespace TestGame
     using FinalEngine.Rendering.OpenGL;
     using FinalEngine.Rendering.OpenGL.Invocation;
     using FinalEngine.Rendering.Pipeline;
-    using OpenTK.Mathematics;
     using OpenTK.Windowing.Common;
     using OpenTK.Windowing.Desktop;
     using OpenTK.Windowing.GraphicsLibraryFramework;
 
-    [StructLayout(LayoutKind.Explicit)]
-    public struct Vertex
-    {
-        public static readonly int SizeInBytes = Marshal.SizeOf<Vertex>();
-
-        [FieldOffset(0)]
-        private Vector3 position;
-
-        [FieldOffset(12)]
-        private Vector4 color;
-
-        public Vertex(Vector3 position, Vector4 color)
-        {
-            this.position = position;
-            this.color = color;
-        }
-
-        public Vector3 Position
-        {
-            get { return this.position; }
-        }
-
-        public Vector4 Color
-        {
-            get { return this.color; }
-        }
-    }
-
-    /// <summary>
-    ///   The main program.
-    /// </summary>
     internal static class Program
     {
-        /// <summary>
-        ///   Defines the entry point of the application.
-        /// </summary>
         private static void Main()
         {
             var settings = new NativeWindowSettings()
@@ -78,7 +42,7 @@ namespace TestGame
                 WindowBorder = WindowBorder.Fixed,
                 WindowState = WindowState.Normal,
 
-                Size = new Vector2i(1024, 768),
+                Size = new OpenTK.Mathematics.Vector2i(1024, 768),
 
                 StartVisible = true,
             };

--- a/TestGame/TestGame.csproj
+++ b/TestGame/TestGame.csproj
@@ -1,44 +1,45 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFramework>net5.0</TargetFramework>
-		<LangVersion>9.0</LangVersion>
-		<Nullable>enable</Nullable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <LangVersion>9.0</LangVersion>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
 
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<NoWarn>1701;1702;SA0001</NoWarn>
-	</PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>1701;1702;SA0001</NoWarn>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
-	</ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="..\Styling\StyleCop\Tests\stylecop.json" Link="stylecop.json" />
+    <AdditionalFiles Include="Vertex.cs" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\FinalEngine.Input\FinalEngine.Input.csproj" />
-		<ProjectReference Include="..\FinalEngine.IO\FinalEngine.IO.csproj" />
-		<ProjectReference Include="..\FinalEngine.Platform.Desktop\FinalEngine.Platform.Desktop.csproj" />
-		<ProjectReference Include="..\FinalEngine.Rendering.OpenGL\FinalEngine.Rendering.OpenGL.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Input\FinalEngine.Input.csproj" />
+    <ProjectReference Include="..\FinalEngine.IO\FinalEngine.IO.csproj" />
+    <ProjectReference Include="..\FinalEngine.Platform.Desktop\FinalEngine.Platform.Desktop.csproj" />
+    <ProjectReference Include="..\FinalEngine.Rendering.OpenGL\FinalEngine.Rendering.OpenGL.csproj" />
+  </ItemGroup>
 
-	<ItemGroup>
-	  <None Update="Resources\Shaders\shader.frag">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
-	  <None Update="Resources\Shaders\shader.vert">
-	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Update="Resources\Shaders\shader.frag">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Shaders\shader.vert">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/TestGame/Vertex.cs
+++ b/TestGame/Vertex.cs
@@ -1,0 +1,63 @@
+﻿// <copyright file="Vertex.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace TestGame
+{
+    using System;
+    using System.Numerics;
+    using System.Runtime.InteropServices;
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct Vertex : IEquatable<Vertex>
+    {
+        public static readonly int SizeInBytes = Marshal.SizeOf<Vertex>();
+
+        [FieldOffset(0)]
+        private Vector3 position;
+
+        [FieldOffset(12)]
+        private Vector4 color;
+
+        public Vertex(Vector3 position, Vector4 color)
+        {
+            this.position = position;
+            this.color = color;
+        }
+
+        public Vector3 Position
+        {
+            get { return this.position; }
+        }
+
+        public Vector4 Color
+        {
+            get { return this.color; }
+        }
+
+        public static bool operator ==(Vertex left, Vertex right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(Vertex left, Vertex right)
+        {
+            return !(left == right);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is Vertex vertex && this.Equals(vertex);
+        }
+
+        public override int GetHashCode()
+        {
+            return (this.position.GetHashCode() * 17) + this.color.GetHashCode();
+        }
+
+        public bool Equals(Vertex other)
+        {
+            return this.position == other.position && this.color == other.color;
+        }
+    }
+}


### PR DESCRIPTION
# Description

This PR provides an abstraction representation of the Input-Assembler Stage of a rendering pipeline. It also provides a few objects which are explained in the Proposed Design section below.

## Dependencies

This PR introduces no new dependencies, but it does depend on [OpenTK.Graphics 4.3.0](https://www.nuget.org/packages/OpenTK.Graphics/).

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I have provided unit tests for all testable changes of the source code. Visual Studio is showing 100% code coverage and I have not added any `[ExcludeFromCodeCoverage]` attributes in this PR, except in the case of test classes. In fact, I've been able to successfully resolve any areas of the code base which were not testable - ie, we are now getting _true_ and _accurate_ 100% code coverage.

Furthermore, I've modified the **TestGame** project to use the newly created `OpenGLInputAssembler` object, the project still runs and now shows _two_ colored triangles using OpenGL 4.6.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-10710U @ 1.10GHz, 32.0 GB
* Toolchain: Microsoft Visual Studio Enterprise 2019 - Version 16.8.2

## Proposed Design

This PR introduces a few new concepts and objects to the engine:

### Vertex & Index Buffers

I've provided two different types of buffers in the form of interfaces, the `IVertexBuffer` and the `IIndexBuffer`, below is their proposed design:

#### Vertex Buffer

```csharp
public interface IVertexBuffer : IDisposable
{
	int Stride { get; }
}
```

The _Stride_ property represents the distance between elements within the buffer, ie; the size in bytes of the `Vertex` struct, in the case of our test game. This is required to allow use of the `IInputLayout` interface, which is supposed to provie a _global_ vertex-to-shader input layout for _all_ vertex buffers, think of it as `glVertexAttribPointer` - except, for all bound buffers, not just those bound to a VAO.

#### Index Buffer

```csharp
public interface IIndexBuffer : IDisposable
{
	int Length { get; }
}
```

The `Length` property represents how many individual elements are contained within the index buffer, in our test game example, that would be 3, one for each vertex. This is almost _always_ going to be the case for index buffers, so it's been hard coded into the `OpenGLIndexBuffer` class.

### Input Layouts

An Input Layout provides a global layout for vertex buffers. OpenGL unfortunately doesn't allow you to set a global input layout for vertices, so I had to create a global VAO, which buffers and layouts can be bound to - essentially _simulating_ global input layouts. You can find the code in `OpenGLRenderContext`. This design decision was made to anticipate the easing in of the Direct3D back-end, which doesn't have the concept of VAOs, as seen [here](https://docs.microsoft.com/en-us/windows/win32/api/d3d11/nf-d3d11-id3d11device-createinputlayout).

### Input Assembler

An Input Assembler basically just provides methods for binding buffers and layouts. Later on when we develop other rendering back-ends this might change, but for now, this is what we have and it works perfectly fine.

### Pseudo Code

```csharp
// Create the global vertex input layout.
var inputElements = new List<InputElement>()
{
	new InputElement(0, 3, InputElementType.Float, Marshal.OffsetOf<Vertex>("position").ToInt32()),
	new InputElement(1, 4, InputElementType.Float, Marshal.OffsetOf<Vertex>("color").ToInt32()),
};

IInputLayout inputLayout = factory.CreateInputLayout(inputElements);

// Bind the layout to the GPU.
inputAssembler.SetInputLayout(inputLayout);

Vertex[] vertices =
{
	new Vertex(new Vector3(-0.9f, -0.5f, 0.0f), new Vector4(1.0f, 0.0f, 0.0f, 1.0f)),
	new Vertex(new Vector3(-0.0f, -0.5f, 0.0f), new Vector4(0.0f, 1.0f, 0.0f, 1.0f)),
	new Vertex(new Vector3(-0.45f, 0.5f, 0.0f), new Vector4(0.0f, 0.0f, 1.0f, 1.0f)),
};

int[] indices =
{
	0, 1, 2,
};

// Create the vertex and index buffer.
IVertexBuffer vertexBuffer = factory.CreateVertexBuffer(vertices, vertices.Length * Vertex.SizeInBytes, Vertex.SizeInBytes);
IIndexBuffer indexBuffer = factory.CreateIndexBuffer(indices, indices.Length * sizeof(int));

// Bind them both.
inputAssembler.SetIndexBuffer(indexBuffer);
inputAssembler.SetVertexBuffer(vertexBuffer);

while (!window.IsExiting)
{
	renderDevice.Clear(Color.Black);
	
	// Draw the triangle to the screen :)
	renderDevice.DrawIndices(PrimitiveTopology.Triangle, 0, indexBuffer.Length);

	renderContext.SwapBuffers();
	window.ProcessEvents();
}
```

## Possible Issues

I've written down a few notes and will be adding issues once I go over them, there a few to keep in mind so I'll post them ASAP.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
