### PR TITLE
[BUG FIX] Fixes #64 - GPU Resources are unbound when new ones are created

### DIFF
--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
@@ -26,11 +26,8 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
 
             this.Length = data.Length;
 
-            this.id = invoker.GenBuffer();
-
-            invoker.BindBuffer(BufferTarget.ElementArrayBuffer, this.id);
-            invoker.BufferData(BufferTarget.ElementArrayBuffer, sizeInBytes, data, BufferUsageHint.StaticDraw);
-            invoker.BindBuffer(BufferTarget.ElementArrayBuffer, 0);
+            this.id = invoker.CreateBuffer();
+            invoker.NamedBufferData(this.id, sizeInBytes, data, BufferUsageHint.StaticDraw);
         }
 
         ~OpenGLIndexBuffer()

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
@@ -26,11 +26,8 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
 
             this.Stride = stride;
 
-            this.id = invoker.GenBuffer();
-
-            invoker.BindBuffer(BufferTarget.ArrayBuffer, this.id);
-            invoker.BufferData(BufferTarget.ArrayBuffer, sizeInBytes, data, BufferUsageHint.StaticDraw);
-            invoker.BindBuffer(BufferTarget.ArrayBuffer, 0);
+            this.id = invoker.CreateBuffer();
+            invoker.NamedBufferData(this.id, sizeInBytes, data, BufferUsageHint.StaticDraw);
         }
 
         ~OpenGLVertexBuffer()

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -42,10 +42,6 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.BlendFunc(BlendingFactor, BlendingFactor)"/>
         void BlendFunc(BlendingFactor sfactor, BlendingFactor dfactor);
 
-        /// <inheritdoc cref="GL.BufferData{T2}(BufferTarget, int, T2[], BufferUsageHint)"/>
-        void BufferData<T2>(BufferTarget target, int size, T2[] data, BufferUsageHint usage)
-            where T2 : struct;
-
         /// <inheritdoc cref="GL.Clear(ClearBufferMask)"/>
         void Clear(ClearBufferMask mask);
 
@@ -60,6 +56,8 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
 
         /// <inheritdoc cref="GL.CompileShader(int)"/>
         void CompileShader(int shader);
+
+        int CreateBuffer();
 
         /// <inheritdoc cref="GL.CreateProgram"/>
         int CreateProgram();
@@ -112,9 +110,6 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.FrontFace(FrontFaceDirection)"/>
         void FrontFace(FrontFaceDirection mode);
 
-        /// <inheritdoc cref="GL.GenBuffer"/>
-        int GenBuffer();
-
         /// <inheritdoc cref="GL.GenTexture"/>
         int GenTexture();
 
@@ -135,6 +130,10 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
 
         /// <inheritdoc cref="GL.LoadBindings(IBindingsContext)"/>
         void LoadBindings(IBindingsContext context);
+
+        /// <inheritdoc cref="GL.NamedBufferData{T2}(int, int, T2[], BufferUsageHint)"/>
+        void NamedBufferData<T2>(int buffer, int size, T2[] data, BufferUsageHint usage)
+            where T2 : struct;
 
         /// <inheritdoc cref="GL.PolygonMode(MaterialFace, PolygonMode)"/>
         void PolygonMode(MaterialFace face, PolygonMode mode);

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -65,6 +65,8 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         /// <inheritdoc cref="GL.CreateShader(ShaderType)"/>
         int CreateShader(ShaderType type);
 
+        int CreateTexture(TextureTarget target);
+
         /// <inheritdoc cref="GL.CullFace(CullFaceMode)"/>
         void CullFace(CullFaceMode mode);
 
@@ -109,9 +111,6 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
 
         /// <inheritdoc cref="GL.FrontFace(FrontFaceDirection)"/>
         void FrontFace(FrontFaceDirection mode);
-
-        /// <inheritdoc cref="GL.GenTexture"/>
-        int GenTexture();
 
         /// <inheritdoc cref="GL.GenVertexArray"/>
         int GenVertexArray();
@@ -158,11 +157,14 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
 
         void Switch(EnableCap cap, bool value);
 
-        /// <inheritdoc cref="GL.TexImage2D(TextureTarget, int, PixelInternalFormat, int, int, int, PixelFormat, PixelType, IntPtr)"/>
-        void TexImage2D(TextureTarget target, int level, PixelInternalFormat internalForamt, int width, int height, int border, PixelFormat format, PixelType type, IntPtr pixels);
+        /// <inheritdoc cref="GL.TextureParameter(int, TextureParameterName, int)"/>
+        void TextureParameter(int texture, TextureParameterName pname, int param);
 
-        /// <inheritdoc cref="GL.TexParameter(TextureTarget, TextureParameterName, int)"/>
-        void TexParameter(TextureTarget target, TextureParameterName name, int param);
+        /// <inheritdoc cref="GL.TextureStorage2D(int, int, SizedInternalFormat, int, int)">
+        void TextureStorage2D(int texture, int levels, SizedInternalFormat internalFormat, int width, int height);
+
+        /// <inheritdoc cref="GL.TextureSubImage2D(int, int, int, int, int, int, PixelFormat, PixelType, IntPtr)"/>
+        void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels);
 
         /// <inheritdoc cref="GL.Uniform1(int, int)"/>
         void Uniform1(int location, int x);

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -120,6 +120,13 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
             return GL.CreateShader(type);
         }
 
+        public int CreateTexture(TextureTarget target)
+        {
+            GL.CreateTextures(target, 1, out int result);
+
+            return result;
+        }
+
         /// <inheritdoc/>
         public void CullFace(CullFaceMode mode)
         {
@@ -208,12 +215,6 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public void FrontFace(FrontFaceDirection mode)
         {
             GL.FrontFace(mode);
-        }
-
-        /// <inheritdoc/>
-        public int GenTexture()
-        {
-            return GL.GenTexture();
         }
 
         /// <inheritdoc/>
@@ -307,16 +308,19 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
             }
         }
 
-        /// <inheritdoc/>
-        public void TexImage2D(TextureTarget target, int level, PixelInternalFormat internalForamt, int width, int height, int border, PixelFormat format, PixelType type, IntPtr pixels)
+        public void TextureParameter(int texture, TextureParameterName pname, int param)
         {
-            GL.TexImage2D(target, level, internalForamt, width, height, border, format, type, pixels);
+            GL.TextureParameter(texture, pname, param);
         }
 
-        /// <inheritdoc/>
-        public void TexParameter(TextureTarget target, TextureParameterName name, int param)
+        public void TextureStorage2D(int texture, int levels, SizedInternalFormat internalFormat, int width, int height)
         {
-            GL.TexParameter(target, name, param);
+            GL.TextureStorage2D(texture, levels, internalFormat, width, height);
+        }
+
+        public void TextureSubImage2D(int texture, int level, int xoffset, int yoffset, int width, int height, PixelFormat format, PixelType type, IntPtr pixels)
+        {
+            GL.TextureSubImage2D(texture, level, xoffset, yoffset, width, height, format, type, pixels);
         }
 
         /// <inheritdoc/>

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -72,13 +72,6 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         }
 
         /// <inheritdoc/>
-        public void BufferData<T2>(BufferTarget target, int size, T2[] data, BufferUsageHint usage)
-            where T2 : struct
-        {
-            GL.BufferData(target, size, data, usage);
-        }
-
-        /// <inheritdoc/>
         public void Clear(ClearBufferMask mask)
         {
             GL.Clear(mask);
@@ -106,6 +99,13 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public void CompileShader(int shader)
         {
             GL.CompileShader(shader);
+        }
+
+        public int CreateBuffer()
+        {
+            GL.CreateBuffers(1, out int result);
+
+            return result;
         }
 
         /// <inheritdoc/>
@@ -211,12 +211,6 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         }
 
         /// <inheritdoc/>
-        public int GenBuffer()
-        {
-            return GL.GenBuffer();
-        }
-
-        /// <inheritdoc/>
         public int GenTexture()
         {
             return GL.GenTexture();
@@ -256,6 +250,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         public void LoadBindings(IBindingsContext context)
         {
             GL.LoadBindings(context);
+        }
+
+        public void NamedBufferData<T2>(int buffer, int size, T2[] data, BufferUsageHint usage)
+            where T2 : struct
+        {
+            GL.NamedBufferData(buffer, size, data, usage);
         }
 
         /// <inheritdoc/>

--- a/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
@@ -74,7 +74,7 @@ namespace FinalEngine.Rendering.OpenGL
         }
 
         [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1011:Closing square brackets should be spaced correctly", Justification = "Conflicting with SA1018")]
-        public ITexture2D CreateTexture2D<T>(Texture2DDescription description, T[]? data, PixelFormat format = PixelFormat.Rgba, PixelFormat internalFormat = PixelFormat.Rgba)
+        public ITexture2D CreateTexture2D<T>(Texture2DDescription description, T[]? data, PixelFormat format = PixelFormat.Rgba, SizedFormat internalFormat = SizedFormat.Rgba8)
         {
             var handle = GCHandle.Alloc(data, GCHandleType.Pinned);
             IntPtr ptr = data == null ? IntPtr.Zero : handle.AddrOfPinnedObject();

--- a/FinalEngine.Rendering.OpenGL/OpenGLPipeline.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLPipeline.cs
@@ -35,8 +35,8 @@ namespace FinalEngine.Rendering.OpenGL
         {
             if (program == null)
             {
-                this.boundProgram = null;
                 this.invoker.UseProgram(0);
+                this.boundProgram = null;
 
                 return;
             }
@@ -55,6 +55,7 @@ namespace FinalEngine.Rendering.OpenGL
             if (texture == null)
             {
                 this.boundTexture?.Unbind();
+                this.boundTexture = null;
 
                 return;
             }

--- a/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
@@ -97,6 +97,10 @@ namespace FinalEngine.Rendering.OpenGL
                 { PixelFormat.Rgba, TKPixelForamt.Rgba },
                 { PixelFormat.Depth, TKPixelForamt.DepthComponent },
                 { PixelFormat.DepthAndStencil, TKPixelForamt.DepthStencil },
+                { SizedFormat.R8, SizedInternalFormat.R8 },
+                { SizedFormat.Rg8, SizedInternalFormat.Rg8 },
+                { SizedFormat.Rgb8, All.Rgb8 },
+                { SizedFormat.Rgba8, SizedInternalFormat.Rgba8 },
             };
 
             this.mapper = new EnumMapper(map);

--- a/FinalEngine.Rendering.OpenGL/Textures/OpenGLTexture.cs
+++ b/FinalEngine.Rendering.OpenGL/Textures/OpenGLTexture.cs
@@ -6,6 +6,7 @@ namespace FinalEngine.Rendering.OpenGL.Textures
 {
     using System;
     using FinalEngine.Rendering.OpenGL.Invocation;
+    using FinalEngine.Rendering.Textures;
     using OpenTK.Graphics.OpenGL4;
     using PixelFormat = FinalEngine.Rendering.Textures.PixelFormat;
 
@@ -19,15 +20,15 @@ namespace FinalEngine.Rendering.OpenGL.Textures
 
         private int id;
 
-        public OpenGLTexture(IOpenGLInvoker invoker, TextureTarget target, PixelFormat format, PixelFormat internalFormat)
+        public OpenGLTexture(IOpenGLInvoker invoker, TextureTarget target, PixelFormat format, SizedFormat internalFormat)
         {
             this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
 
-            this.id = invoker.GenTexture();
+            this.id = invoker.CreateTexture(target);
             this.target = target;
 
             this.Format = format;
-            this.InternalForamt = internalFormat;
+            this.InternalFormat = internalFormat;
         }
 
         ~OpenGLTexture()
@@ -37,7 +38,20 @@ namespace FinalEngine.Rendering.OpenGL.Textures
 
         public PixelFormat Format { get; }
 
-        public PixelFormat InternalForamt { get; }
+        public SizedFormat InternalFormat { get; }
+
+        protected int ID
+        {
+            get
+            {
+                if (this.IsDisposed)
+                {
+                    throw new ObjectDisposedException(nameof(OpenGLTexture));
+                }
+
+                return this.id;
+            }
+        }
 
         protected bool IsDisposed { get; private set; }
 

--- a/FinalEngine.Rendering.OpenGL/Textures/OpenGLTexture.cs
+++ b/FinalEngine.Rendering.OpenGL/Textures/OpenGLTexture.cs
@@ -18,13 +18,11 @@ namespace FinalEngine.Rendering.OpenGL.Textures
 
         private readonly TextureTarget target;
 
-        private int id;
-
         public OpenGLTexture(IOpenGLInvoker invoker, TextureTarget target, PixelFormat format, SizedFormat internalFormat)
         {
             this.invoker = invoker ?? throw new ArgumentNullException(nameof(invoker), $"The specified {nameof(invoker)} parameter cannot be null.");
 
-            this.id = invoker.CreateTexture(target);
+            this.ID = invoker.CreateTexture(target);
             this.target = target;
 
             this.Format = format;
@@ -40,18 +38,7 @@ namespace FinalEngine.Rendering.OpenGL.Textures
 
         public SizedFormat InternalFormat { get; }
 
-        protected int ID
-        {
-            get
-            {
-                if (this.IsDisposed)
-                {
-                    throw new ObjectDisposedException(nameof(OpenGLTexture));
-                }
-
-                return this.id;
-            }
-        }
+        protected int ID { get; private set; }
 
         protected bool IsDisposed { get; private set; }
 
@@ -62,7 +49,7 @@ namespace FinalEngine.Rendering.OpenGL.Textures
                 throw new ObjectDisposedException(nameof(OpenGLTexture));
             }
 
-            this.invoker.BindTexture(this.target, this.id);
+            this.invoker.BindTexture(this.target, this.ID);
         }
 
         public void Dispose()
@@ -98,10 +85,10 @@ namespace FinalEngine.Rendering.OpenGL.Textures
                 return;
             }
 
-            if (disposing && this.id != -1)
+            if (disposing && this.ID != -1)
             {
-                this.invoker.DeleteTexture(this.id);
-                this.id = -1;
+                this.invoker.DeleteTexture(this.ID);
+                this.ID = -1;
             }
 
             this.IsDisposed = true;

--- a/FinalEngine.Rendering.OpenGL/Textures/OpenGLTexture2D.cs
+++ b/FinalEngine.Rendering.OpenGL/Textures/OpenGLTexture2D.cs
@@ -16,7 +16,7 @@ namespace FinalEngine.Rendering.OpenGL.Textures
 
     public class OpenGLTexture2D : OpenGLTexture, ITexture2D
     {
-        public OpenGLTexture2D(IOpenGLInvoker invoker, IEnumMapper mapper, Texture2DDescription description, PixelFormat format, PixelFormat internalFormat, IntPtr data)
+        public OpenGLTexture2D(IOpenGLInvoker invoker, IEnumMapper mapper, Texture2DDescription description, PixelFormat format, SizedFormat internalFormat, IntPtr data)
             : base(invoker, TextureTarget.Texture2D, format, internalFormat)
         {
             if (mapper == null)
@@ -26,25 +26,23 @@ namespace FinalEngine.Rendering.OpenGL.Textures
 
             this.Description = description;
 
-            this.Bind();
+            invoker.TextureStorage2D(this.ID, 1, mapper.Forward<SizedInternalFormat>(this.InternalFormat), description.Width, description.Height);
 
-            invoker.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)mapper.Forward<TextureMinFilter>(description.MinFilter));
-            invoker.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)mapper.Forward<TextureMagFilter>(description.MagFilter));
-            invoker.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)mapper.Forward<TKTextureWrapMode>(description.WrapS));
-            invoker.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)mapper.Forward<TKTextureWrapMode>(description.WrapT));
+            invoker.TextureParameter(this.ID, TextureParameterName.TextureMinFilter, (int)mapper.Forward<TextureMinFilter>(description.MinFilter));
+            invoker.TextureParameter(this.ID, TextureParameterName.TextureMagFilter, (int)mapper.Forward<TextureMagFilter>(description.MagFilter));
+            invoker.TextureParameter(this.ID, TextureParameterName.TextureWrapS, (int)mapper.Forward<TKTextureWrapMode>(description.WrapS));
+            invoker.TextureParameter(this.ID, TextureParameterName.TextureWrapT, (int)mapper.Forward<TKTextureWrapMode>(description.WrapT));
 
-            invoker.TexImage2D(
-                target: TextureTarget.Texture2D,
+            invoker.TextureSubImage2D(
+                texture: this.ID,
                 level: 0,
-                internalForamt: mapper.Forward<PixelInternalFormat>(internalFormat),
+                xoffset: 0,
+                yoffset: 0,
                 width: description.Width,
                 height: description.Height,
-                border: 0,
-                format: mapper.Forward<TKPixelForamt>(format),
+                format: mapper.Forward<TKPixelForamt>(this.Format),
                 type: mapper.Forward<TKPixelType>(description.PixelType),
                 pixels: data);
-
-            this.Unbind();
         }
 
         public Texture2DDescription Description { get; }

--- a/FinalEngine.Rendering/IGPUResourceFactory.cs
+++ b/FinalEngine.Rendering/IGPUResourceFactory.cs
@@ -22,7 +22,7 @@ namespace FinalEngine.Rendering
         IShaderProgram CreateShaderProgram(IEnumerable<IShader> shaders);
 
         [SuppressMessage("StyleCop.CSharp.SpacingRules", "SA1011:Closing square brackets should be spaced correctly", Justification = "Conflicting with SA1018")]
-        ITexture2D CreateTexture2D<T>(Texture2DDescription description, T[]? data, PixelFormat format = PixelFormat.Rgba, PixelFormat internalFormat = PixelFormat.Rgba);
+        ITexture2D CreateTexture2D<T>(Texture2DDescription description, T[]? data, PixelFormat format = PixelFormat.Rgba, SizedFormat internalFormat = SizedFormat.Rgba8);
 
         IVertexBuffer CreateVertexBuffer<T>(T[] data, int sizeInBytes, int stride)
                             where T : struct;

--- a/FinalEngine.Rendering/Textures/ITexture.cs
+++ b/FinalEngine.Rendering/Textures/ITexture.cs
@@ -10,6 +10,6 @@ namespace FinalEngine.Rendering.Textures
     {
         PixelFormat Format { get; }
 
-        PixelFormat InternalForamt { get; }
+        SizedFormat InternalFormat { get; }
     }
 }

--- a/FinalEngine.Rendering/Textures/PixelFormat.cs
+++ b/FinalEngine.Rendering/Textures/PixelFormat.cs
@@ -18,4 +18,15 @@ namespace FinalEngine.Rendering.Textures
 
         DepthAndStencil,
     }
+
+    public enum SizedFormat
+    {
+        R8,
+
+        Rg8,
+
+        Rgb8,
+
+        Rgba8,
+    }
 }

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -48,20 +48,6 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
-        public void ConstructorShouldInvokeBindBufferIdentifierWhenInvoked()
-        {
-            // Assert
-            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, ID), Times.Once);
-        }
-
-        [Test]
-        public void ConstructorShouldInvokeBindBufferZeroWhenInvoked()
-        {
-            // Assert
-            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ElementArrayBuffer, 0), Times.Once);
-        }
-
-        [Test]
         public void ConstructorShouldInvokeCreateBufferWhenInvoked()
         {
             // Assert

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLIndexBufferTests.cs
@@ -62,17 +62,17 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
-        public void ConstructorShouldInvokeBufferDataWhenInvoked()
+        public void ConstructorShouldInvokeCreateBufferWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.BufferData(BufferTarget.ElementArrayBuffer, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
+            this.invoker.Verify(x => x.CreateBuffer(), Times.Once);
         }
 
         [Test]
-        public void ConstructorShouldInvokeGenBufferWhenInvoked()
+        public void ConstructorShouldInvokeNamedBufferDataWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.GenBuffer(), Times.Once);
+            this.invoker.Verify(x => x.NamedBufferData(ID, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
         }
 
         [Test]
@@ -111,7 +111,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         {
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
-            this.invoker.Setup(x => x.GenBuffer()).Returns(ID);
+            this.invoker.Setup(x => x.CreateBuffer()).Returns(ID);
             this.indexBuffer = new OpenGLIndexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int));
         }
 

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -47,20 +47,6 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
-        public void ConstructorShouldInvokeBindBufferIdentifierWhenInvoked()
-        {
-            // Assert
-            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, ID), Times.Once);
-        }
-
-        [Test]
-        public void ConstructorShouldInvokeBindBufferZeroWhenInvoked()
-        {
-            // Assert
-            this.invoker.Verify(x => x.BindBuffer(BufferTarget.ArrayBuffer, 0), Times.Once);
-        }
-
-        [Test]
         public void ConstructorShouldInvokeCreateBufferWhenInvoked()
         {
             // Assert

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -61,17 +61,17 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         }
 
         [Test]
-        public void ConstructorShouldInvokeBufferDataWhenInvoked()
+        public void ConstructorShouldInvokeCreateBufferWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.BufferData(BufferTarget.ArrayBuffer, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
+            this.invoker.Verify(x => x.CreateBuffer(), Times.Once);
         }
 
         [Test]
-        public void ConstructorShouldInvokeGenBufferWhenInvoked()
+        public void ConstructorShouldInvokeNamedBufferDataWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.GenBuffer(), Times.Once);
+            this.invoker.Verify(x => x.NamedBufferData(ID, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
         }
 
         [Test]
@@ -103,7 +103,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         {
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
-            this.invoker.Setup(x => x.GenBuffer()).Returns(ID);
+            this.invoker.Setup(x => x.CreateBuffer()).Returns(ID);
             this.vertexBuffer = new OpenGLVertexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int), Stride);
         }
 

--- a/FinalEngine.Tests/Rendering/OpenGL/Textures/OpenGLTexture2DTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Textures/OpenGLTexture2DTests.cs
@@ -63,6 +63,13 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
         }
 
         [Test]
+        public void ConstructorShouldInvokeTextureStorage2DWhenInvoked()
+        {
+            // Assert
+            this.invoker.Verify(x => x.TextureStorage2D(ID, 1, this.mapper.Object.Forward<SizedInternalFormat>(this.texture.InternalFormat), this.description.Width, this.description.Height));
+        }
+
+        [Test]
         public void ConstructorShouldInvokeTextureSubImage2DWhenInvoked()
         {
             // Assert

--- a/FinalEngine.Tests/Rendering/OpenGL/Textures/OpenGLTexture2DTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Textures/OpenGLTexture2DTests.cs
@@ -24,6 +24,8 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
     [SuppressMessage("Design", "CA1001:Types that own disposable fields should be disposable", Justification = "This is done in TearDown.")]
     public class OpenGLTexture2DTests
     {
+        private const int ID = 104;
+
         private Texture2DDescription description;
 
         private Mock<IOpenGLInvoker> invoker;
@@ -33,45 +35,45 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
         private OpenGLTexture2D texture;
 
         [Test]
-        public void ConstructorShouldInvokeTexImage2DWhenInvoked()
+        public void ConstructorShouldInvokeTextureParameterMagFilterWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.TexImage2D(TextureTarget.Texture2D, 0, this.mapper.Object.Forward<PixelInternalFormat>(this.texture.InternalForamt), 20, 30, 0, this.mapper.Object.Forward<TKPixelFormat>(this.texture.Format), this.mapper.Object.Forward<TKPixelType>(this.description.PixelType), new IntPtr(1)), Times.Once);
+            this.invoker.Verify(x => x.TextureParameter(ID, TextureParameterName.TextureMagFilter, (int)this.mapper.Object.Forward<TextureMagFilter>(this.description.MagFilter)), Times.Once);
         }
 
         [Test]
-        public void ConstructorShouldInvokeTexParameterMagFilterWhenInvoked()
+        public void ConstructorShouldInvokeTextureParameterMinFilterWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMagFilter, (int)this.mapper.Object.Forward<TextureMagFilter>(this.description.MagFilter)), Times.Once);
+            this.invoker.Verify(x => x.TextureParameter(ID, TextureParameterName.TextureMinFilter, (int)this.mapper.Object.Forward<TextureMinFilter>(this.description.MinFilter)), Times.Once);
         }
 
         [Test]
-        public void ConstructorShouldInvokeTexParameterMinFilterWhenInvoked()
+        public void ConstructorShouldInvokeTextureParameterWrapSWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMinFilter, (int)this.mapper.Object.Forward<TextureMinFilter>(this.description.MinFilter)), Times.Once);
+            this.invoker.Verify(x => x.TextureParameter(ID, TextureParameterName.TextureWrapS, (int)this.mapper.Object.Forward<TKTextureWrapMode>(this.description.WrapS)), Times.Once);
         }
 
         [Test]
-        public void ConstructorShouldInvokeTexParameterWrapSWhenInvoked()
+        public void ConstructorShouldInvokeTextureParameterWrapTWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapS, (int)this.mapper.Object.Forward<TKTextureWrapMode>(this.description.WrapS)), Times.Once);
+            this.invoker.Verify(x => x.TextureParameter(ID, TextureParameterName.TextureWrapT, (int)this.mapper.Object.Forward<TKTextureWrapMode>(this.description.WrapT)), Times.Once);
         }
 
         [Test]
-        public void ConstructorShouldInvokeTexParameterWrapTWhenInvoked()
+        public void ConstructorShouldInvokeTextureSubImage2DWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureWrapT, (int)this.mapper.Object.Forward<TKTextureWrapMode>(this.description.WrapT)), Times.Once);
+            this.invoker.Verify(x => x.TextureSubImage2D(ID, 0, 0, 0, this.description.Width, this.description.Height, this.mapper.Object.Forward<TKPixelFormat>(this.texture.Format), this.mapper.Object.Forward<TKPixelType>(this.description.PixelType), new IntPtr(1)));
         }
 
         [Test]
         public void ConstructorShouldThrowArgumentNullExceptionWhenMapperIsNull()
         {
             // Arrange, act and assert
-            Assert.Throws<ArgumentNullException>(() => new OpenGLTexture2D(this.invoker.Object, null, default, PixelFormat.Depth, PixelFormat.Depth, new IntPtr(1)));
+            Assert.Throws<ArgumentNullException>(() => new OpenGLTexture2D(this.invoker.Object, null, default, PixelFormat.Depth, SizedFormat.R8, new IntPtr(1)));
         }
 
         [Test]
@@ -89,6 +91,8 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
         {
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
+            this.invoker.Setup(x => x.CreateTexture(TextureTarget.Texture2D)).Returns(ID);
+
             this.mapper = new Mock<IEnumMapper>();
 
             this.description = new Texture2DDescription()
@@ -102,7 +106,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
                 WrapT = TextureWrapMode.Repeat,
             };
 
-            this.texture = new OpenGLTexture2D(this.invoker.Object, this.mapper.Object, this.description, PixelFormat.Rgba, PixelFormat.Rgb, new IntPtr(1));
+            this.texture = new OpenGLTexture2D(this.invoker.Object, this.mapper.Object, this.description, PixelFormat.Rgba, SizedFormat.R8, new IntPtr(1));
         }
 
         [TearDown]

--- a/FinalEngine.Tests/Rendering/OpenGL/Textures/OpenGLTextureTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Textures/OpenGLTextureTests.cs
@@ -8,6 +8,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
     using System.Diagnostics.CodeAnalysis;
     using FinalEngine.Rendering.OpenGL.Invocation;
     using FinalEngine.Rendering.OpenGL.Textures;
+    using FinalEngine.Rendering.Textures;
     using Moq;
     using NUnit.Framework;
     using OpenTK.Graphics.OpenGL4;
@@ -47,14 +48,14 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
         public void ConstructorShouldInvokeGenTextureWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.GenTexture(), Times.Once);
+            this.invoker.Verify(x => x.CreateTexture(TextureTarget.Texture2D), Times.Once);
         }
 
         [Test]
         public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsNull()
         {
             // Arrange, act and assert
-            Assert.Throws<ArgumentNullException>(() => new OpenGLTexture(null, TextureTarget.Texture2D, PixelFormat.Rgba, PixelFormat.Rgba));
+            Assert.Throws<ArgumentNullException>(() => new OpenGLTexture(null, TextureTarget.Texture2D, PixelFormat.Rgba, SizedFormat.R8));
         }
 
         [Test]
@@ -71,10 +72,10 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
         public void InternalFormatShouldReturnRgWhenInvoked()
         {
             // Act
-            PixelFormat actual = this.texture.InternalForamt;
+            SizedFormat actual = this.texture.InternalFormat;
 
             // Assert
-            Assert.AreEqual(PixelFormat.Rg, actual);
+            Assert.AreEqual(SizedFormat.R8, actual);
         }
 
         [SetUp]
@@ -82,9 +83,9 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Textures
         {
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
-            this.invoker.Setup(x => x.GenTexture()).Returns(ID);
+            this.invoker.Setup(x => x.CreateTexture(TextureTarget.Texture2D)).Returns(ID);
 
-            this.texture = new OpenGLTexture(this.invoker.Object, TextureTarget.Texture2D, PixelFormat.Rgba, PixelFormat.Rg);
+            this.texture = new OpenGLTexture(this.invoker.Object, TextureTarget.Texture2D, PixelFormat.Rgba, SizedFormat.R8);
         }
 
         [Test]

--- a/Goal.txt
+++ b/Goal.txt
@@ -3,7 +3,7 @@ Sprinty Sprint:
 19/12/2020 - 19/01/2021
 
 - #64 - [BUG] GPU Resources are unbound when new ones are created
-- #59 - [BUG] OpenGL Backend not checking for error or warning status
+- #59 - [BUG] OpenGL Back-end not checking for error or warning status
 - #73 - [FEATURE REQUEST] Logging Framework
 - #67 - [DOCUMENTATION] Rendering API Documentation
 - #68 - [FEATURE REQUEST] Texture Loader

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -54,7 +54,7 @@ namespace TestGame
                 }
             }
 
-            return factory.CreateTexture2D(description, data, FinalEngine.Rendering.Textures.PixelFormat.Rgba, FinalEngine.Rendering.Textures.PixelFormat.Rgba);
+            return factory.CreateTexture2D(description, data);
         }
 
         private static void Main()
@@ -213,6 +213,10 @@ namespace TestGame
             ITexture2D texture = LoadTextureFromFile(factory, "Resources\\Textures\\default.png");
 
             pipeline.SetTexture(texture, 0);
+
+            ITexture2D otherTex = LoadTextureFromFile(factory, "Resources\\Textures\\wood.png");
+
+            pipeline.SetTexture(otherTex, 0);
 
             Console.WriteLine(GL.GetError());
 


### PR DESCRIPTION
# Description

This PR resolves the issue where resources that can be bound to the GPU are unbound when new ones are created.

Fixes #64 

## Dependencies

There are no new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

I've provided unit tests for all testable parts of the code base. I've also tested the code in a real world example by creating new resources after binding other resources to the GPU and everything seems to work out fine 😄.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-10710U @ 1.10GHz, 32.0 GB
* Toolchain: Microsoft Visual Studio Enterprise 2019 - Version 16.8.2

## Proposed Design

This PR doesn't introduced any API changes.

### Pseudo Code

No Pseudo Code is required to show my changes.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
