### PR TITLE
[BUG FIX] Fixes #59 - OpenGL Backend not checking for error or warning status

### DIFF
--- a/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShader.cs
+++ b/FinalEngine.Rendering.OpenGL/Pipeline/OpenGLShader.cs
@@ -32,11 +32,11 @@ namespace FinalEngine.Rendering.OpenGL.Pipeline
 
             this.EntryPoint = mapper.Reverse<PipelineTarget>(type);
 
-            this.id = this.invoker.CreateShader(type);
-            this.invoker.ShaderSource(this.id, sourceCode);
-            this.invoker.CompileShader(this.id);
+            this.id = invoker.CreateShader(type);
+            invoker.ShaderSource(this.id, sourceCode);
+            invoker.CompileShader(this.id);
 
-            string? log = this.invoker.GetShaderInfoLog(this.id);
+            string? log = invoker.GetShaderInfoLog(this.id);
 
             if (!string.IsNullOrWhiteSpace(log))
             {

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -22,7 +22,6 @@ namespace TestGame
     using FinalEngine.Rendering.OpenGL.Invocation;
     using FinalEngine.Rendering.Pipeline;
     using FinalEngine.Rendering.Textures;
-    using OpenTK.Graphics.OpenGL4;
     using OpenTK.Windowing.Common;
     using OpenTK.Windowing.Desktop;
     using OpenTK.Windowing.GraphicsLibraryFramework;
@@ -217,8 +216,6 @@ namespace TestGame
             ITexture2D otherTex = LoadTextureFromFile(factory, "Resources\\Textures\\wood.png");
 
             pipeline.SetTexture(otherTex, 0);
-
-            Console.WriteLine(GL.GetError());
 
             float temp = 0.0f;
             var random = new Random();


### PR DESCRIPTION
# Description

This PR resolves the issue where OpenGL wasn't logging error or debug information.

Fixes #59 

## Dependencies

There are no new dependencies.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

In it's current state, the debugging information is occurring inside the `OpenGLInvoker` class, which cannot be tested. However, at a later date, perhaps when I implement more rendering back-ends (such as DirectX or Vulkan) we can look at abstracting the error callback into it's own class so it can be tested. That being said, I have checked whether or not errors and warnings are logged correctly and all seems well and good 😄.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-10710U @ 1.10GHz, 32.0 GB
* Toolchain: Microsoft Visual Studio Enterprise 2019 - Version 16.8.2

## Proposed Design

This PR doesn't introduced any API changes.

### Pseudo Code

No pseudo code is required to show my changes.

## Possible Issues

There are no issues I can think of off the top of my head.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
