### PR TITLE
[FEATURE] Updateable Buffers

### DIFF
--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLIndexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLIndexBuffer.cs
@@ -22,6 +22,15 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// </exception>
         void Bind();
 
+        /// <summary>
+        ///   Updates the vertex buffer by filling it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="TData">
+        ///   The type of data to fill the buffer with.
+        /// </typeparam>
+        /// <param name="data">
+        ///   The data to fill with the buffer with.
+        /// </param>
         void Update<TData>(IReadOnlyCollection<TData> data)
             where TData : struct;
     }

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLIndexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLIndexBuffer.cs
@@ -5,6 +5,7 @@
 namespace FinalEngine.Rendering.OpenGL.Buffers
 {
     using System;
+    using System.Collections.Generic;
     using FinalEngine.Rendering.Buffers;
 
     /// <summary>
@@ -20,5 +21,8 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         ///   The <see cref="IOpenGLIndexBuffer"/> has been disposed.
         /// </exception>
         void Bind();
+
+        void Update<TData>(IReadOnlyCollection<TData> data)
+            where TData : struct;
     }
 }

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
@@ -21,6 +21,18 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// </exception>
         void Bind();
 
+        /// <summary>
+        ///   Updates the vertex buffer by filling it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="TData">
+        ///   The type of data to fill the buffer with.
+        /// </typeparam>
+        /// <param name="data">
+        ///   The data to fill with the buffer with.
+        /// </param>
+        /// <param name="stride">
+        ///   The total number of bytes a single vertex contains.
+        /// </param>
         void Update<TData>(IReadOnlyCollection<TData> data, int stride)
             where TData : struct;
     }

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
@@ -21,7 +21,7 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// </exception>
         void Bind();
 
-        void Update<TData>(IReadOnlyCollection<TData> data)
+        void Update<TData>(IReadOnlyCollection<TData> data, int stride)
             where TData : struct;
     }
 }

--- a/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/IOpenGLVertexBuffer.cs
@@ -4,6 +4,7 @@
 
 namespace FinalEngine.Rendering.OpenGL.Buffers
 {
+    using System.Collections.Generic;
     using FinalEngine.Rendering.Buffers;
 
     /// <summary>
@@ -19,5 +20,8 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         ///   The <see cref="IOpenGLVertexBuffer"/> has been disposed.
         /// </exception>
         void Bind();
+
+        void Update<TData>(IReadOnlyCollection<TData> data)
+            where TData : struct;
     }
 }

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
@@ -133,8 +133,8 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
                 throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
             }
 
-            this.Length = data.Count * Marshal.SizeOf<TData>();
-            this.invoker.NamedBufferSubData(this.rendererID, IntPtr.Zero, this.Length, data.ToArray());
+            this.Length = data.Count;
+            this.invoker.NamedBufferSubData(this.rendererID, IntPtr.Zero, this.Length * Marshal.SizeOf<TData>(), data.ToArray());
         }
 
         /// <summary>

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLIndexBuffer.cs
@@ -39,6 +39,12 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// <param name="invoker">
         ///   Specifies an <see cref="IOpenGLInvoker"/> that represents the invoker used to invoke OpenGL calls.
         /// </param>
+        /// <param name="mapper">
+        ///   Specifies an <see cref="IEnumMapper"/> that represents the enumeration mapper used to map OpenGL enumerations to the rendering APIs equivalent.
+        /// </param>
+        /// <param name="usage">
+        ///   Specifies a <see cref="BufferUsageHint"/> that represents how the index buffer will be used.
+        /// </param>
         /// <param name="data">
         ///   Specifies an <see cref="IReadOnlyCollection{T}"/> that represents the data this <see cref="OpenGLIndexBuffer{T}"/> will contain.
         /// </param>
@@ -46,7 +52,7 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         ///   Specifies an <see cref="int"/> that represents the size in bytes of the specified <paramref name="data"/>.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        ///   The specified <paramref name="invoker"/> or <paramref name="data"/> parameter is null.
+        ///   The specified <paramref name="invoker"/>, <paramref name="mapper"/> or <paramref name="data"/> parameter is null.
         /// </exception>
         public OpenGLIndexBuffer(IOpenGLInvoker invoker, IEnumMapper mapper, BufferUsageHint usage, IReadOnlyCollection<T> data, int sizeInBytes)
         {
@@ -85,6 +91,12 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// </value>
         public int Length { get; private set; }
 
+        /// <summary>
+        ///   Gets the usage type for this <see cref="OpenGLIndexBuffer{T}"/>.
+        /// </summary>
+        /// <value>
+        ///   The usage type for this <see cref="OpenGLIndexBuffer{T}"/>.
+        /// </value>
         public BufferUsageType Type { get; }
 
         /// <summary>
@@ -120,6 +132,21 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        ///   Updates the vertex buffer by filling it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="TData">
+        ///   The type of data to fill the buffer with.
+        /// </typeparam>
+        /// <param name="data">
+        ///   The data to fill with the buffer with.
+        /// </param>
+        /// <exception cref="ObjectDisposedException">
+        ///   The <see cref="OpenGLIndexBuffer{T}"/> has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   The specified <paramref name="data"/> parameter is null.
+        /// </exception>
         public void Update<TData>(IReadOnlyCollection<TData> data)
             where TData : struct
         {

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
@@ -39,6 +39,12 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// <param name="invoker">
         ///   Specifies an <see cref="IOpenGLInvoker"/> that represents the invoker used to invoke OpenGL calls.
         /// </param>
+        /// <param name="mapper">
+        ///   Specifies an <see cref="IEnumMapper"/> that represents the enumeration mapper used to map OpenGL enumerations to the rendering APIs equivalent.
+        /// </param>
+        /// <param name="usage">
+        ///   Specifies a <see cref="BufferUsageHint"/> that represents how the index buffer will be used.
+        /// </param>
         /// <param name="data">
         ///   Specifies an <see cref="IReadOnlyCollection{T}"/> that represents the data this <see cref="OpenGLVertexBuffer{T}"/> will contain.
         /// </param>
@@ -49,7 +55,7 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         ///   Specifies an <see cref="int"/> that represents the total number of bytes a single vertex contains.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        ///   The specified <paramref name="invoker"/> or <paramref name="data"/> parameter is null.
+        ///   The specified <paramref name="invoker"/>, <paramref name="mapper"/> or <paramref name="data"/> parameter is null.
         /// </exception>
         public OpenGLVertexBuffer(IOpenGLInvoker invoker, IEnumMapper mapper, BufferUsageHint usage, IReadOnlyCollection<T> data, int sizeInBytes, int stride)
         {
@@ -88,6 +94,12 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// </value>
         public int Stride { get; private set; }
 
+        /// <summary>
+        ///   Gets the usage type for this <see cref="OpenGLVertexBuffer{T}"/>.
+        /// </summary>
+        /// <value>
+        ///   The usage type for this <see cref="OpenGLVertexBuffer{T}"/>.
+        /// </value>
         public BufferUsageType Type { get; }
 
         /// <summary>
@@ -123,6 +135,24 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        ///   Updates the vertex buffer by filling it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="TData">
+        ///   The type of data to fill the buffer with.
+        /// </typeparam>
+        /// <param name="data">
+        ///   The data to fill with the buffer with.
+        /// </param>
+        /// <param name="stride">
+        ///   The total number of bytes a single vertex contains.
+        /// </param>
+        /// <exception cref="ObjectDisposedException">
+        ///   The <see cref="OpenGLVertexBuffer{T}"/> has been disposed.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        ///   The specified <paramref name="data"/> parameter is null.
+        /// </exception>
         public void Update<TData>(IReadOnlyCollection<TData> data, int stride)
             where TData : struct
         {

--- a/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
+++ b/FinalEngine.Rendering.OpenGL/Buffers/OpenGLVertexBuffer.cs
@@ -86,7 +86,7 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
         /// <value>
         ///   The total number of bytes for a single vertex contained in this <see cref="OpenGLVertexBuffer{T}"/>.
         /// </value>
-        public int Stride { get; }
+        public int Stride { get; private set; }
 
         public BufferUsageType Type { get; }
 
@@ -123,7 +123,7 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
             GC.SuppressFinalize(this);
         }
 
-        public void Update<TData>(IReadOnlyCollection<TData> data)
+        public void Update<TData>(IReadOnlyCollection<TData> data, int stride)
             where TData : struct
         {
             if (this.IsDisposed)
@@ -135,6 +135,8 @@ namespace FinalEngine.Rendering.OpenGL.Buffers
             {
                 throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
             }
+
+            this.Stride = stride;
 
             this.invoker.NamedBufferSubData(this.rendererID, IntPtr.Zero, data.Count * Marshal.SizeOf<TData>(), data.ToArray());
         }

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -151,7 +151,8 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
             where T2 : struct;
 
         /// <inheritdoc cref="GL.NamedBufferSubData{T3}(int, IntPtr, int, T3[])"/>
-        void NamedBufferSubData<T3>(int buffer, IntPtr offset, int size, T3[] data);
+        void NamedBufferSubData<T3>(int buffer, IntPtr offset, int size, T3[] data)
+            where T3 : struct;
 
         /// <inheritdoc cref="GL.PolygonMode(MaterialFace, PolygonMode)"/>
         void PolygonMode(MaterialFace face, PolygonMode mode);

--- a/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/IOpenGLInvoker.cs
@@ -150,6 +150,9 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
         void NamedBufferData<T2>(int buffer, int size, T2[] data, BufferUsageHint usage)
             where T2 : struct;
 
+        /// <inheritdoc cref="GL.NamedBufferSubData{T3}(int, IntPtr, int, T3[])"/>
+        void NamedBufferSubData<T3>(int buffer, IntPtr offset, int size, T3[] data);
+
         /// <inheritdoc cref="GL.PolygonMode(MaterialFace, PolygonMode)"/>
         void PolygonMode(MaterialFace face, PolygonMode mode);
 

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -308,6 +308,7 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
             GL.NamedBufferData(buffer, size, data, usage);
         }
 
+        /// <inheritdoc/>
         public void NamedBufferSubData<T3>(int buffer, IntPtr offset, int size, T3[] data)
             where T3 : struct
         {

--- a/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
+++ b/FinalEngine.Rendering.OpenGL/Invocation/OpenGLInvoker.cs
@@ -308,6 +308,12 @@ namespace FinalEngine.Rendering.OpenGL.Invocation
             GL.NamedBufferData(buffer, size, data, usage);
         }
 
+        public void NamedBufferSubData<T3>(int buffer, IntPtr offset, int size, T3[] data)
+            where T3 : struct
+        {
+            GL.NamedBufferSubData(buffer, offset, size, data);
+        }
+
         /// <inheritdoc/>
         public void PolygonMode(MaterialFace face, PolygonMode mode)
         {

--- a/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
@@ -208,7 +208,7 @@ namespace FinalEngine.Rendering.OpenGL
         /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="data"/> parameter is null.
         /// </exception>
-        public IVertexBuffer CreateVertexBuffer<T>(IReadOnlyCollection<T> data, int sizeInBytes, int stride)
+        public IVertexBuffer CreateVertexBuffer<T>(BufferUsageType type, IReadOnlyCollection<T> data, int sizeInBytes, int stride)
             where T : struct
         {
             if (data == null)
@@ -216,7 +216,7 @@ namespace FinalEngine.Rendering.OpenGL
                 throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
             }
 
-            return new OpenGLVertexBuffer<T>(this.invoker, data, sizeInBytes, stride);
+            return new OpenGLVertexBuffer<T>(this.invoker, this.mapper, this.mapper.Forward<BufferUsageHint>(type), data, sizeInBytes, stride);
         }
     }
 }

--- a/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
@@ -74,7 +74,7 @@ namespace FinalEngine.Rendering.OpenGL
         /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="data"/> parameter is null.
         /// </exception>
-        public IIndexBuffer CreateIndexBuffer<T>(IReadOnlyCollection<T> data, int sizeInBytes)
+        public IIndexBuffer CreateIndexBuffer<T>(BufferUsageType type, IReadOnlyCollection<T> data, int sizeInBytes)
             where T : struct
         {
             if (data == null)
@@ -82,7 +82,7 @@ namespace FinalEngine.Rendering.OpenGL
                 throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
             }
 
-            return new OpenGLIndexBuffer<T>(this.invoker, data, sizeInBytes);
+            return new OpenGLIndexBuffer<T>(this.invoker, this.mapper, this.mapper.Forward<BufferUsageHint>(type), data, sizeInBytes);
         }
 
         /// <summary>

--- a/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLGPUResourceFactory.cs
@@ -62,6 +62,9 @@ namespace FinalEngine.Rendering.OpenGL
         /// <typeparam name="T">
         ///   Specifies the type of data the <see cref="IIndexBuffer"/> will contain.
         /// </typeparam>
+        /// <param name="type">
+        ///   Specifies a <see cref="BufferUsageType"/> that represents the buffer usage type.
+        /// </param>
         /// <param name="data">
         ///   Specifies an <see cref="IReadOnlyCollection{T}"/> that represents the data the buffer will contain.
         /// </param>
@@ -193,6 +196,9 @@ namespace FinalEngine.Rendering.OpenGL
         /// <typeparam name="T">
         ///   The type of data the buffer will contain.
         /// </typeparam>
+        /// <param name="type">
+        ///   Specifies a <see cref="BufferUsageType"/> that represents the buffer usage type.
+        /// </param>
         /// <param name="data">
         ///   Specifies an <see cref="IReadOnlyCollection{T}"/> that represents the data the buffer will contain.
         /// </param>

--- a/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
@@ -5,6 +5,7 @@
 namespace FinalEngine.Rendering.OpenGL
 {
     using System;
+    using System.Collections.Generic;
     using FinalEngine.Rendering.Buffers;
     using FinalEngine.Rendering.OpenGL.Buffers;
     using FinalEngine.Rendering.OpenGL.Invocation;
@@ -135,6 +136,22 @@ namespace FinalEngine.Rendering.OpenGL
             }
 
             glVertexBuffer.Bind();
+        }
+
+        public void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data)
+            where T : struct
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer), $"The specified {nameof(buffer)} parameter cannot be null.");
+            }
+
+            if (buffer is not IOpenGLVertexBuffer glVertexBuffer)
+            {
+                throw new ArgumentException($"The specified {nameof(buffer)} parameter is not of type {nameof(IOpenGLVertexBuffer)}.", nameof(buffer));
+            }
+
+            glVertexBuffer.Update(data);
         }
     }
 }

--- a/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
@@ -138,6 +138,24 @@ namespace FinalEngine.Rendering.OpenGL
             glVertexBuffer.Bind();
         }
 
+        /// <summary>
+        ///   Updates the specified index <paramref name="buffer"/> and fills it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type of data to fill with the buffer with.
+        /// </typeparam>
+        /// <param name="buffer">
+        ///   The buffer to fill.
+        /// </param>
+        /// <param name="data">
+        ///   The data to fill the buffer with.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   The specified <paramref name="buffer"/> or <paramref name="data"/> parameter is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   The specified <paramref name="buffer"/> is not the correct implementation. If this exception occurs, you're attempting to update an index buffer that does not implement <see cref="IOpenGLIndexBuffer"/>.
+        /// </exception>
         public void UpdateIndexBuffer<T>(IIndexBuffer buffer, IReadOnlyCollection<T> data)
             where T : struct
         {
@@ -159,6 +177,27 @@ namespace FinalEngine.Rendering.OpenGL
             glIndexBuffer.Update(data);
         }
 
+        /// <summary>
+        ///   Updates the specified vertex <paramref name="buffer"/> and fills it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type of data to fill with the buffer with.
+        /// </typeparam>
+        /// <param name="buffer">
+        ///   The buffer to fill.
+        /// </param>
+        /// <param name="data">
+        ///   The data to fill the buffer with.
+        /// </param>
+        /// <param name="stride">
+        ///   The total number of bytes for a single vertex.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        ///   The specified <paramref name="buffer"/> or <paramref name="data"/> parameter is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        ///   The specified <paramref name="buffer"/> is not the correct implementation. If this exception occurs, you're attempting to update a vertex buffer that does not implement <see cref="IOpenGLVertexBuffer"/>.
+        /// </exception>
         public void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data, int stride)
             where T : struct
         {

--- a/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLInputAssembler.cs
@@ -138,7 +138,7 @@ namespace FinalEngine.Rendering.OpenGL
             glVertexBuffer.Bind();
         }
 
-        public void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data)
+        public void UpdateIndexBuffer<T>(IIndexBuffer buffer, IReadOnlyCollection<T> data)
             where T : struct
         {
             if (buffer == null)
@@ -146,12 +146,38 @@ namespace FinalEngine.Rendering.OpenGL
                 throw new ArgumentNullException(nameof(buffer), $"The specified {nameof(buffer)} parameter cannot be null.");
             }
 
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
+            }
+
+            if (buffer is not IOpenGLIndexBuffer glIndexBuffer)
+            {
+                throw new ArgumentException($"The specified {nameof(buffer)} parameter is not of type {nameof(IOpenGLVertexBuffer)}.", nameof(buffer));
+            }
+
+            glIndexBuffer.Update(data);
+        }
+
+        public void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data, int stride)
+            where T : struct
+        {
+            if (buffer == null)
+            {
+                throw new ArgumentNullException(nameof(buffer), $"The specified {nameof(buffer)} parameter cannot be null.");
+            }
+
+            if (data == null)
+            {
+                throw new ArgumentNullException(nameof(data), $"The specified {nameof(data)} parameter cannot be null.");
+            }
+
             if (buffer is not IOpenGLVertexBuffer glVertexBuffer)
             {
                 throw new ArgumentException($"The specified {nameof(buffer)} parameter is not of type {nameof(IOpenGLVertexBuffer)}.", nameof(buffer));
             }
 
-            glVertexBuffer.Update(data);
+            glVertexBuffer.Update(data, stride);
         }
     }
 }

--- a/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
@@ -118,6 +118,8 @@ namespace FinalEngine.Rendering.OpenGL
                 { SizedFormat.Rg8, SizedInternalFormat.Rg8 },
                 { SizedFormat.Rgb8, All.Rgb8 },
                 { SizedFormat.Rgba8, SizedInternalFormat.Rgba8 },
+                { BufferUsageType.Static, BufferUsageHint.StaticDraw },
+                { BufferUsageType.Dynamic, BufferUsageHint.DynamicDraw },
             };
 
             this.mapper = new EnumMapper(map);

--- a/FinalEngine.Rendering/Buffers/BufferUsageType.cs
+++ b/FinalEngine.Rendering/Buffers/BufferUsageType.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="BufferUsageType.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Rendering.Buffers
+{
+    public enum BufferUsageType
+    {
+        Static,
+
+        Dynamic,
+    }
+}

--- a/FinalEngine.Rendering/Buffers/BufferUsageType.cs
+++ b/FinalEngine.Rendering/Buffers/BufferUsageType.cs
@@ -4,10 +4,19 @@
 
 namespace FinalEngine.Rendering.Buffers
 {
+    /// <summary>
+    ///   Enumerates the available buffer usage types.
+    /// </summary>
     public enum BufferUsageType
     {
+        /// <summary>
+        ///   The data contained in the buffer is static and will not change.
+        /// </summary>
         Static,
 
+        /// <summary>
+        ///   The data contained in the buffer is dynamic and is subject to change.
+        /// </summary>
         Dynamic,
     }
 }

--- a/FinalEngine.Rendering/Buffers/IIndexBuffer.cs
+++ b/FinalEngine.Rendering/Buffers/IIndexBuffer.cs
@@ -20,6 +20,12 @@ namespace FinalEngine.Rendering.Buffers
         /// </value>
         int Length { get; }
 
+        /// <summary>
+        ///   Gets the usage type for this <see cref="IIndexBuffer"/>.
+        /// </summary>
+        /// <value>
+        ///   The usage type for this <see cref="IIndexBuffer"/>.
+        /// </value>
         BufferUsageType Type { get; }
     }
 }

--- a/FinalEngine.Rendering/Buffers/IIndexBuffer.cs
+++ b/FinalEngine.Rendering/Buffers/IIndexBuffer.cs
@@ -19,5 +19,7 @@ namespace FinalEngine.Rendering.Buffers
         ///   The total amount of indices contained in this <see cref="IIndexBuffer"/>.
         /// </value>
         int Length { get; }
+
+        BufferUsageType Type { get; }
     }
 }

--- a/FinalEngine.Rendering/Buffers/IVertexBuffer.cs
+++ b/FinalEngine.Rendering/Buffers/IVertexBuffer.cs
@@ -20,6 +20,12 @@ namespace FinalEngine.Rendering.Buffers
         /// </value>
         int Stride { get; }
 
+        /// <summary>
+        ///   Gets the usage type for this <see cref="IVertexBuffer"/>.
+        /// </summary>
+        /// <value>
+        ///   The usage type for this <see cref="IVertexBuffer"/>.
+        /// </value>
         BufferUsageType Type { get; }
     }
 }

--- a/FinalEngine.Rendering/Buffers/IVertexBuffer.cs
+++ b/FinalEngine.Rendering/Buffers/IVertexBuffer.cs
@@ -19,5 +19,7 @@ namespace FinalEngine.Rendering.Buffers
         ///   The total number of bytes for a single vertex contained in this <see cref="IVertexBuffer"/>.
         /// </value>
         int Stride { get; }
+
+        BufferUsageType Type { get; }
     }
 }

--- a/FinalEngine.Rendering/IGPUResourceFactory.cs
+++ b/FinalEngine.Rendering/IGPUResourceFactory.cs
@@ -21,6 +21,9 @@ namespace FinalEngine.Rendering
         /// <typeparam name="T">
         ///   Specifies the type of data the <see cref="IIndexBuffer"/> will contain.
         /// </typeparam>
+        /// <param name="type">
+        ///   Specifies a <see cref="BufferUsageType"/> that represents the buffer usage type.
+        /// </param>
         /// <param name="data">
         ///   Specifies an <see cref="IReadOnlyCollection{T}"/> that represents the data the buffer will contain.
         /// </param>
@@ -110,6 +113,9 @@ namespace FinalEngine.Rendering
         /// <typeparam name="T">
         ///   Specifies the type of data the buffer will contain.
         /// </typeparam>
+        /// <param name="type">
+        ///   Specifies a <see cref="BufferUsageType"/> that represents the buffer usage type.
+        /// </param>
         /// <param name="data">
         ///   Specifies an <see cref="IReadOnlyCollection{T}"/> that represents the data the buffer will contain.
         /// </param>

--- a/FinalEngine.Rendering/IGPUResourceFactory.cs
+++ b/FinalEngine.Rendering/IGPUResourceFactory.cs
@@ -125,7 +125,7 @@ namespace FinalEngine.Rendering
         /// <returns>
         ///   The newly created <see cref="IVertexBuffer"/>.
         /// </returns>
-        IVertexBuffer CreateVertexBuffer<T>(IReadOnlyCollection<T> data, int sizeInBytes, int stride)
-                            where T : struct;
+        IVertexBuffer CreateVertexBuffer<T>(BufferUsageType type, IReadOnlyCollection<T> data, int sizeInBytes, int stride)
+            where T : struct;
     }
 }

--- a/FinalEngine.Rendering/IGPUResourceFactory.cs
+++ b/FinalEngine.Rendering/IGPUResourceFactory.cs
@@ -33,7 +33,7 @@ namespace FinalEngine.Rendering
         /// <returns>
         ///   The newly created <see cref="IIndexBuffer"/>.
         /// </returns>
-        IIndexBuffer CreateIndexBuffer<T>(IReadOnlyCollection<T> data, int sizeInBytes)
+        IIndexBuffer CreateIndexBuffer<T>(BufferUsageType type, IReadOnlyCollection<T> data, int sizeInBytes)
             where T : struct;
 
         /// <summary>

--- a/FinalEngine.Rendering/IInputAssembler.cs
+++ b/FinalEngine.Rendering/IInputAssembler.cs
@@ -55,7 +55,10 @@ namespace FinalEngine.Rendering
         /// </exception>
         void SetVertexBuffer(IVertexBuffer? buffer);
 
-        void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data)
+        void UpdateIndexBuffer<T>(IIndexBuffer buffer, IReadOnlyCollection<T> data)
+            where T : struct;
+
+        void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data, int stride)
             where T : struct;
     }
 }

--- a/FinalEngine.Rendering/IInputAssembler.cs
+++ b/FinalEngine.Rendering/IInputAssembler.cs
@@ -55,9 +55,36 @@ namespace FinalEngine.Rendering
         /// </exception>
         void SetVertexBuffer(IVertexBuffer? buffer);
 
+        /// <summary>
+        ///   Updates the specified index <paramref name="buffer"/> and fills it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type of data to fill with the buffer with.
+        /// </typeparam>
+        /// <param name="buffer">
+        ///   The buffer to fill.
+        /// </param>
+        /// <param name="data">
+        ///   The data to fill the buffer with.
+        /// </param>
         void UpdateIndexBuffer<T>(IIndexBuffer buffer, IReadOnlyCollection<T> data)
             where T : struct;
 
+        /// <summary>
+        ///   Updates the specified vertex <paramref name="buffer"/> and fills it with the specified <paramref name="data"/>.
+        /// </summary>
+        /// <typeparam name="T">
+        ///   The type of data to fill with the buffer with.
+        /// </typeparam>
+        /// <param name="buffer">
+        ///   The buffer to fill.
+        /// </param>
+        /// <param name="data">
+        ///   The data to fill the buffer with.
+        /// </param>
+        /// <param name="stride">
+        ///   The total number of bytes for a single vertex.
+        /// </param>
         void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data, int stride)
             where T : struct;
     }

--- a/FinalEngine.Rendering/IInputAssembler.cs
+++ b/FinalEngine.Rendering/IInputAssembler.cs
@@ -5,6 +5,7 @@
 namespace FinalEngine.Rendering
 {
     using System;
+    using System.Collections.Generic;
     using FinalEngine.Rendering.Buffers;
 
     /// <summary>
@@ -53,5 +54,8 @@ namespace FinalEngine.Rendering
         ///   The specified <paramref name="buffer"/> is not the correct implementation. If this exception occurs, you're attempting to bind an vertex buffer that was created with a different rendering API than the one that's currently in use.
         /// </exception>
         void SetVertexBuffer(IVertexBuffer? buffer);
+
+        void UpdateVertexBuffer<T>(IVertexBuffer buffer, IReadOnlyCollection<T> data)
+            where T : struct;
     }
 }

--- a/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/Buffers/OpenGLVertexBufferTests.cs
@@ -6,8 +6,11 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Runtime.InteropServices;
+    using FinalEngine.Rendering.Buffers;
     using FinalEngine.Rendering.OpenGL.Buffers;
     using FinalEngine.Rendering.OpenGL.Invocation;
+    using FinalEngine.Utilities;
     using Moq;
     using NUnit.Framework;
     using OpenTK.Graphics.OpenGL4;
@@ -23,6 +26,8 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         private readonly int[] data = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, };
 
         private Mock<IOpenGLInvoker> invoker;
+
+        private Mock<IEnumMapper> mapper;
 
         private OpenGLVertexBuffer<int> vertexBuffer;
 
@@ -57,21 +62,28 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         public void ConstructorShouldInvokeNamedBufferDataWhenInvoked()
         {
             // Assert
-            this.invoker.Verify(x => x.NamedBufferData(ID, this.data.Length * sizeof(int), this.data, BufferUsageHint.StaticDraw), Times.Once);
+            this.invoker.Verify(x => x.NamedBufferData(ID, this.data.Length * sizeof(int), this.data, BufferUsageHint.StreamCopy), Times.Once);
         }
 
         [Test]
         public void ConstructorShouldThrowArgumentNullExceptionWhenDataIsNull()
         {
             // Arrange, act and assert
-            Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(this.invoker.Object, null, this.data.Length * sizeof(int), 0));
+            Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(this.invoker.Object, this.mapper.Object, BufferUsageHint.DynamicRead, null, this.data.Length * sizeof(int), 0));
         }
 
         [Test]
         public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsNull()
         {
             // Arrange, act and assert
-            Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(null, this.data, this.data.Length * sizeof(int), Stride));
+            Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(null, this.mapper.Object, BufferUsageHint.DynamicCopy, this.data, this.data.Length * sizeof(int), Stride));
+        }
+
+        [Test]
+        public void ConstructorShouldThrowArgumentNullExceptionWhenMapperIsNull()
+        {
+            // Arrange, act and assert
+            Assert.Throws<ArgumentNullException>(() => new OpenGLVertexBuffer<int>(this.invoker.Object, null, BufferUsageHint.StreamDraw, this.data, this.data.Length * sizeof(int), Stride));
         }
 
         [Test]
@@ -90,7 +102,11 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
             this.invoker.Setup(x => x.CreateBuffer()).Returns(ID);
-            this.vertexBuffer = new OpenGLVertexBuffer<int>(this.invoker.Object, this.data, this.data.Length * sizeof(int), Stride);
+
+            this.mapper = new Mock<IEnumMapper>();
+            this.mapper.Setup(x => x.Reverse<BufferUsageType>(It.IsAny<BufferUsageHint>())).Returns(BufferUsageType.Static);
+
+            this.vertexBuffer = new OpenGLVertexBuffer<int>(this.invoker.Object, this.mapper.Object, BufferUsageHint.StreamCopy, this.data, this.data.Length * sizeof(int), Stride);
         }
 
         [Test]
@@ -104,6 +120,62 @@ namespace FinalEngine.Tests.Rendering.OpenGL.Buffers
         public void Teardown()
         {
             this.vertexBuffer.Dispose();
+        }
+
+        [Test]
+        public void TypeShouldReturnStaticWhenInvoked()
+        {
+            // Arrange
+            const BufferUsageType Expected = BufferUsageType.Static;
+
+            // Act
+            BufferUsageType actual = this.vertexBuffer.Type;
+
+            // Assert
+            Assert.AreEqual(Expected, actual);
+        }
+
+        [Test]
+        public void UpdateSholdThrowArgumentNullExceptionWhenDataIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.vertexBuffer.Update<int>(null, 0));
+        }
+
+        [Test]
+        public void UpdateShouldInvokeNamedBufferSubDataWhenInvoked()
+        {
+            // Arrange
+            int[] array = new int[12];
+
+            // Act
+            this.vertexBuffer.Update(array, 0);
+
+            // Assert
+            this.invoker.Verify(x => x.NamedBufferSubData(ID, IntPtr.Zero, array.Length * Marshal.SizeOf<int>(), array));
+        }
+
+        [Test]
+        public void UpdateShouldSetStridePropertyToSevenWhenInvoked()
+        {
+            // Arrange
+            const int Expected = 7;
+
+            // Act
+            this.vertexBuffer.Update(Array.Empty<int>(), Expected);
+
+            // Assert
+            Assert.AreEqual(Expected, this.vertexBuffer.Stride);
+        }
+
+        [Test]
+        public void UpdateShouldThrowObjectDisposedExceptionWhenDisposed()
+        {
+            // Arrange
+            this.vertexBuffer.Dispose();
+
+            // Act and assert
+            Assert.Throws<ObjectDisposedException>(() => this.vertexBuffer.Update(Array.Empty<int>(), 0));
         }
     }
 }

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLGPUResourceFactoryTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLGPUResourceFactoryTests.cs
@@ -47,7 +47,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         public void CreateIndexBufferShouldReturnOpenGLIndexBufferWhenInvoked()
         {
             // Act
-            IIndexBuffer actual = this.factory.CreateIndexBuffer<int>(Array.Empty<int>(), 0);
+            IIndexBuffer actual = this.factory.CreateIndexBuffer<int>(BufferUsageType.Static, Array.Empty<int>(), 0);
 
             // Assert
             Assert.IsInstanceOf(typeof(OpenGLIndexBuffer<int>), actual);
@@ -57,7 +57,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         public void CreateIndexBufferShouldThrowArgumentNullExceptionWhenDataIsNull()
         {
             // Act and assert
-            Assert.Throws<ArgumentNullException>(() => this.factory.CreateIndexBuffer<int>(null, 0));
+            Assert.Throws<ArgumentNullException>(() => this.factory.CreateIndexBuffer<int>(BufferUsageType.Dynamic, null, 0));
         }
 
         [Test]
@@ -162,7 +162,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         public void CreateVertexBufferShouldReturnOpenGLVertexBufferWhenInvoked()
         {
             // Act
-            IVertexBuffer actual = this.factory.CreateVertexBuffer(Array.Empty<int>(), 0, 0);
+            IVertexBuffer actual = this.factory.CreateVertexBuffer(BufferUsageType.Dynamic, Array.Empty<int>(), 0, 0);
 
             // Assert
             Assert.IsInstanceOf(typeof(OpenGLVertexBuffer<int>), actual);
@@ -172,7 +172,7 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         public void CreateVertexBufferShouldThrowArgumentNullExceptionWhenDataIsNull()
         {
             // Act and assert
-            Assert.Throws<ArgumentNullException>(() => this.factory.CreateVertexBuffer<int>(null, 0, 0));
+            Assert.Throws<ArgumentNullException>(() => this.factory.CreateVertexBuffer<int>(BufferUsageType.Static, null, 0, 0));
         }
 
         [SetUp]

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLInputAssemblerTests.cs
@@ -17,9 +17,13 @@ namespace FinalEngine.Tests.Rendering.OpenGL
     [ExcludeFromCodeCoverage]
     public class OpenGLInputAssemblerTests
     {
+        private Mock<IOpenGLIndexBuffer> indexBuffer;
+
         private OpenGLInputAssembler inputAssembler;
 
         private Mock<IOpenGLInvoker> invoker;
+
+        private Mock<IOpenGLVertexBuffer> vertexBuffer;
 
         [Test]
         public void ConstructorShouldThrowArgumentNullExceptionWhenInvokerIsNull()
@@ -127,6 +131,9 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         {
             // Arrange
             this.invoker = new Mock<IOpenGLInvoker>();
+            this.vertexBuffer = new Mock<IOpenGLVertexBuffer>();
+            this.indexBuffer = new Mock<IOpenGLIndexBuffer>();
+
             this.inputAssembler = new OpenGLInputAssembler(this.invoker.Object);
         }
 
@@ -158,6 +165,68 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         {
             // Act and assert
             Assert.Throws<ArgumentException>(() => this.inputAssembler.SetVertexBuffer(Mock.Of<IVertexBuffer>()));
+        }
+
+        [Test]
+        public void UpdateIndexBufferShouldInvokeIndexBufferUpdate()
+        {
+            // Act
+            this.inputAssembler.UpdateIndexBuffer(this.indexBuffer.Object, Array.Empty<int>());
+
+            // Assert
+            this.indexBuffer.Verify(x => x.Update(Array.Empty<int>()));
+        }
+
+        [Test]
+        public void UpdateIndexBufferShouldThrowArgumentExceptionWhenBufferIsNotOpenGLIndexBuffer()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentException>(() => this.inputAssembler.UpdateIndexBuffer(Mock.Of<IIndexBuffer>(), Array.Empty<int>()));
+        }
+
+        [Test]
+        public void UpdateIndexBufferShouldThrowArgumentNullExceptionWhenBufferIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.inputAssembler.UpdateIndexBuffer(null, Array.Empty<int>()));
+        }
+
+        [Test]
+        public void UpdateIndexBufferShouldThrowArgumentNullExceptionWhenDataIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.inputAssembler.UpdateIndexBuffer<int>(this.indexBuffer.Object, null));
+        }
+
+        [Test]
+        public void UpdateVertexBufferShouldInvokeVertexBufferUpdate()
+        {
+            // Act
+            this.inputAssembler.UpdateVertexBuffer(this.vertexBuffer.Object, Array.Empty<int>(), 2);
+
+            // Assert
+            this.vertexBuffer.Verify(x => x.Update(Array.Empty<int>(), 2));
+        }
+
+        [Test]
+        public void UpdateVertexBufferShouldThrowArgumentExceptionWhenBufferIsNotOpenGLVertexBuffer()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentException>(() => this.inputAssembler.UpdateVertexBuffer(Mock.Of<IVertexBuffer>(), Array.Empty<int>(), 0));
+        }
+
+        [Test]
+        public void UpdateVertexBufferShouldThrowArgumentNullExceptionWhenBufferIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.inputAssembler.UpdateVertexBuffer(null, Array.Empty<int>(), 0));
+        }
+
+        [Test]
+        public void UpdateVertexBufferShouldThrowArgumentNullExceptionWhenDataIsNull()
+        {
+            // Act and assert
+            Assert.Throws<ArgumentNullException>(() => this.inputAssembler.UpdateVertexBuffer<int>(this.vertexBuffer.Object, null, 0));
         }
     }
 }

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -5,6 +5,8 @@
 namespace TestGame
 {
     using System;
+    using System.Collections.Generic;
+    using System.IO;
     using FinalEngine.Input.Keyboard;
     using FinalEngine.Input.Mouse;
     using FinalEngine.IO;
@@ -12,8 +14,10 @@ namespace TestGame
     using FinalEngine.Platform.Desktop.OpenTK;
     using FinalEngine.Platform.Desktop.OpenTK.Invocation;
     using FinalEngine.Rendering;
+    using FinalEngine.Rendering.Buffers;
     using FinalEngine.Rendering.OpenGL;
     using FinalEngine.Rendering.OpenGL.Invocation;
+    using FinalEngine.Rendering.Pipeline;
     using OpenTK.Windowing.Common;
     using OpenTK.Windowing.Desktop;
     using OpenTK.Windowing.GraphicsLibraryFramework;
@@ -65,6 +69,26 @@ namespace TestGame
             IOutputMerger outputMerger = renderDevice.OutputMerger;
             IPipeline pipeline = renderDevice.Pipeline;
             IGPUResourceFactory factory = renderDevice.Factory;
+
+            IShaderProgram? program = factory.CreateShaderProgram(
+                new List<IShader>()
+                {
+                    factory.CreateShader(PipelineTarget.Vertex, File.ReadAllText("Resources\\Shaders\\shader.vert")),
+                    factory.CreateShader(PipelineTarget.Fragment, File.ReadAllText("Resources\\Shaders\\shader.frag")),
+                });
+
+            pipeline.SetShaderProgram(program);
+
+            IInputLayout? inputLayout = factory.CreateInputLayout(
+                new List<InputElement>()
+                {
+                    new InputElement(0, 3, InputElementType.Float, 0),
+                    new InputElement(1, 3, InputElementType.Float, 3 * sizeof(float)),
+                });
+
+            inputAssembler.SetInputLayout(inputLayout);
+
+            IVertexBuffer vertexBuffer = factory.CreateVertexBuffer(BufferUsageType.Dynamic, Array.Empty<float>(), 1000 * sizeof(float), 6 * sizeof(float));
 
             while (!window.IsExiting)
             {

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -6,6 +6,7 @@ namespace TestGame
 {
     using System;
     using System.Collections.Generic;
+    using System.Drawing;
     using System.IO;
     using FinalEngine.Input.Keyboard;
     using FinalEngine.Input.Mouse;
@@ -83,17 +84,40 @@ namespace TestGame
                 new List<InputElement>()
                 {
                     new InputElement(0, 3, InputElementType.Float, 0),
-                    new InputElement(1, 3, InputElementType.Float, 3 * sizeof(float)),
+                    new InputElement(1, 4, InputElementType.Float, 3 * sizeof(float)),
                 });
 
             inputAssembler.SetInputLayout(inputLayout);
 
-            IVertexBuffer vertexBuffer = factory.CreateVertexBuffer(BufferUsageType.Dynamic, Array.Empty<float>(), 1000 * sizeof(float), 6 * sizeof(float));
+            float[] vertices =
+            {
+                -0.5f, -0.5f, 0.0f, 1, 0, 0, 1,
+                0.5f, -0.5f, 0.0f, 0, 1, 0, 1,
+                0.0f, 0.5f, 0.0f, 0, 0, 1, 1,
+            };
+
+            int[] indices =
+            {
+                0, 1, 2,
+            };
+
+            IVertexBuffer vertexBuffer = factory.CreateVertexBuffer(BufferUsageType.Dynamic, Array.Empty<float>(), 1000 * sizeof(float), 7 * sizeof(float));
+            IIndexBuffer indexBuffer = factory.CreateIndexBuffer(BufferUsageType.Dynamic, Array.Empty<int>(), 3 * sizeof(int));
 
             while (!window.IsExiting)
             {
                 keyboard.Update();
                 mouse.Update();
+
+                inputAssembler.UpdateVertexBuffer(vertexBuffer, vertices, 7 * sizeof(float));
+                inputAssembler.UpdateIndexBuffer(indexBuffer, indices);
+
+                inputAssembler.SetVertexBuffer(vertexBuffer);
+                inputAssembler.SetIndexBuffer(indexBuffer);
+
+                renderDevice.Clear(Color.CornflowerBlue);
+                renderDevice.DrawIndices(PrimitiveTopology.Triangle, 0, indexBuffer.Length);
+
                 renderContext.SwapBuffers();
                 window.ProcessEvents();
             }

--- a/TestGame/Program.cs
+++ b/TestGame/Program.cs
@@ -22,6 +22,7 @@ namespace TestGame
     using OpenTK.Windowing.Common;
     using OpenTK.Windowing.Desktop;
     using OpenTK.Windowing.GraphicsLibraryFramework;
+    using MouseButton = FinalEngine.Input.Mouse.MouseButton;
 
     internal static class Program
     {
@@ -89,31 +90,56 @@ namespace TestGame
 
             inputAssembler.SetInputLayout(inputLayout);
 
-            float[] vertices =
-            {
-                -0.5f, -0.5f, 0.0f, 1, 0, 0, 1,
-                0.5f, -0.5f, 0.0f, 0, 1, 0, 1,
-                0.0f, 0.5f, 0.0f, 0, 0, 1, 1,
-            };
-
-            int[] indices =
-            {
-                0, 1, 2,
-            };
-
             IVertexBuffer vertexBuffer = factory.CreateVertexBuffer(BufferUsageType.Dynamic, Array.Empty<float>(), 1000 * sizeof(float), 7 * sizeof(float));
             IIndexBuffer indexBuffer = factory.CreateIndexBuffer(BufferUsageType.Dynamic, Array.Empty<int>(), 3 * sizeof(int));
 
+            inputAssembler.SetVertexBuffer(vertexBuffer);
+            inputAssembler.SetIndexBuffer(indexBuffer);
+
+            float r = 1.0f;
+            float g = 1.0f;
+            float b = 1.0f;
+
             while (!window.IsExiting)
             {
+                if (mouse.IsButtonReleased(MouseButton.Left))
+                {
+                    r = 0.2f;
+                    g = 1.0f;
+                    b = 0.5f;
+                }
+
+                if (mouse.IsButtonReleased(MouseButton.Right))
+                {
+                    r = 0.67f;
+                    g = 0.4f;
+                    b = 0.82f;
+                }
+
+                if (mouse.IsButtonReleased(MouseButton.Middle))
+                {
+                    r = 0.27f;
+                    g = 0.2f;
+                    b = 0.62f;
+                }
+
                 keyboard.Update();
                 mouse.Update();
 
+                float[] vertices =
+                {
+                    -0.5f, -0.5f, 0.0f, r, g, b, 1,
+                    0.5f, -0.5f, 0.0f, g, b, r, 1,
+                    0.0f, 0.5f, 0.0f, g, r, b, 1,
+                };
+
+                int[] indices =
+                {
+                    0, 1, 2,
+                };
+
                 inputAssembler.UpdateVertexBuffer(vertexBuffer, vertices, 7 * sizeof(float));
                 inputAssembler.UpdateIndexBuffer(indexBuffer, indices);
-
-                inputAssembler.SetVertexBuffer(vertexBuffer);
-                inputAssembler.SetIndexBuffer(indexBuffer);
 
                 renderDevice.Clear(Color.CornflowerBlue);
                 renderDevice.DrawIndices(PrimitiveTopology.Triangle, 0, indexBuffer.Length);

--- a/TestGame/Resources/Shaders/shader.frag
+++ b/TestGame/Resources/Shaders/shader.frag
@@ -1,13 +1,10 @@
 ﻿#version 460
 
 layout (location = 0) in vec4 in_color;
-layout (location = 1) in vec2 in_texCoord;
 
 out vec4 out_color;
 
-uniform sampler2D u_texture;
-
 void main()
 {
-    out_color = texture(u_texture, in_texCoord) * in_color;
+    out_color = in_color;
 }

--- a/TestGame/Resources/Shaders/shader.vert
+++ b/TestGame/Resources/Shaders/shader.vert
@@ -2,19 +2,11 @@
 
 layout (location = 0) in vec3 in_position;
 layout (location = 1) in vec4 in_color;
-layout (location = 2) in vec2 in_texCoord;
 
 layout (location = 0) out vec4 out_color;
-layout (location = 1) out vec2 out_texCoord;
-
-uniform mat4 u_projection;
-uniform mat4 u_view;
-uniform mat4 u_model;
 
 void main()
 {
-	out_color		= in_color;
-	out_texCoord	= in_texCoord;
-
-	gl_Position = u_projection * u_view * u_model * vec4(in_position, 1.0);
+	out_color = in_color;
+	gl_Position = vec4(in_position, 1.0);
 }


### PR DESCRIPTION
# Description

Vertex and index buffers can now be updated in preparation for 2D batch rendering.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I've provided unit tests for all testable changes and provides an example in the test game project.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: i7-10710U, 32GB RAM
* Toolchain: VS Enterprise 2019 

## Proposed Design

Super duper simple design:

```csharp
// Setup code
IInputLayout? inputLayout = factory.CreateInputLayout(
	new List<InputElement>()
	{
		new InputElement(0, 3, InputElementType.Float, 0),
		new InputElement(1, 4, InputElementType.Float, 3 * sizeof(float)),
	});

inputAssembler.SetInputLayout(inputLayout);

// Create the buffer with no data and an initial max capacity.
IVertexBuffer vertexBuffer = factory.CreateVertexBuffer(BufferUsageType.Dynamic, Array.Empty<float>(), 1000 * sizeof(float), 7 * sizeof(float));
IIndexBuffer indexBuffer = factory.CreateIndexBuffer(BufferUsageType.Dynamic, Array.Empty<int>(), 3 * sizeof(int));

// Update the buffers to fill the content somewhere else in the codebase like so:
inputAssembler.UpdateVertexBuffer(vertexBuffer, vertices, 7 * sizeof(float));
inputAssembler.UpdateIndexBuffer(indexBuffer, indices);

// Then just bind them and draw them as normal.
inputAssembler.SetVertexBuffer(vertexBuffer);
inputAssembler.SetIndexBuffer(indexBuffer);

renderDevice.Clear(Color.CornflowerBlue);
renderDevice.DrawIndices(PrimitiveTopology.Triangle, 0, indexBuffer.Length);
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
