### PR TITLE
FE-5 - Visual Studio like UI elements.

### DIFF
--- a/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
+++ b/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net5.0</TargetFramework>
+		<LangVersion>9.0</LangVersion>
+		<Nullable>enable</Nullable>
+		<AnalysisMode>All</AnalysisMode>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<NoWarn>1701;1702;SA0001;IDE0079</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>FinalEngine.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+</Project>

--- a/FinalEngine.Editor.Desktop/App.xaml
+++ b/FinalEngine.Editor.Desktop/App.xaml
@@ -1,0 +1,14 @@
+﻿<Application x:Class="FinalEngine.Editor.Desktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Blue.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Colors.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Controls.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="App.xaml.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Desktop
+{
+    using System.Windows;
+    using FinalEngine.Editor.Desktop.Views;
+
+    /// <summary>
+    ///   Interaction logic for App.xaml.
+    /// </summary>
+    public partial class App : Application
+    {
+        /// <summary>
+        ///   Raises the <see cref="Application.Startup"/> event.
+        /// </summary>
+        /// <param name="e">
+        ///   A <see cref="StartupEventArgs"/> that contains the event data.
+        /// </param>
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            var view = new MainView();
+            view.Show();
+        }
+    }
+}

--- a/FinalEngine.Editor.Desktop/AssemblyInfo.cs
+++ b/FinalEngine.Editor.Desktop/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+// <copyright file="AssemblyInfo.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+using System.Windows;
+
+[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]

--- a/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
+++ b/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
@@ -1,0 +1,37 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<OutputType>WinExe</OutputType>
+		<TargetFramework>net5.0-windows</TargetFramework>
+		<UseWPF>true</UseWPF>
+		<LangVersion>9.0</LangVersion>
+		<Nullable>enable</Nullable>
+		<AnalysisMode>All</AnalysisMode>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<NoWarn>1701;1702;SA0001;IDE0079</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="MahApps.Metro" Version="2.4.9" />
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>FinalEngine.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+</Project>

--- a/FinalEngine.Editor.Desktop/Views/MainView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/MainView.xaml
@@ -1,0 +1,30 @@
+﻿<mah:MetroWindow x:Name="Window"
+                 x:Class="FinalEngine.Editor.Desktop.Views.MainView"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 mc:Ignorable="d"
+                 Width="800"
+                 Height="450"
+                 WindowStartupLocation="CenterScreen"
+                 WindowState="Maximized"
+                 GlowBrush="{DynamicResource MahApps.Brushes.Accent2}"
+                 NonActiveGlowBrush="{DynamicResource MahApps.Brushes.Accent4}"
+                 BorderThickness="2">
+
+    <!-- MAIN MENU -->
+    <mah:MetroWindow.LeftWindowCommands>
+        <mah:WindowCommands ShowLastSeparator="False">
+            <Menu IsMainMenu="True">
+                <MenuItem Header="_File">
+                    <MenuItem Header="E_xit" Command="{Binding ExitCommand}" CommandParameter="{Binding ElementName=Window}" />
+                </MenuItem>
+            </Menu>
+        </mah:WindowCommands>
+    </mah:MetroWindow.LeftWindowCommands>
+
+    <Grid>
+    </Grid>
+</mah:MetroWindow>

--- a/FinalEngine.Editor.Desktop/Views/MainView.xaml.cs
+++ b/FinalEngine.Editor.Desktop/Views/MainView.xaml.cs
@@ -1,0 +1,22 @@
+﻿// <copyright file="MainView.xaml.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Desktop.Views
+{
+    using MahApps.Metro.Controls;
+
+    /// <summary>
+    ///   Interaction logic for MainView.xaml.
+    /// </summary>
+    public partial class MainView : MetroWindow
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="MainView"/> class.
+        /// </summary>
+        public MainView()
+        {
+            this.InitializeComponent();
+        }
+    }
+}

--- a/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
+++ b/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net5.0</TargetFramework>
+		<LangVersion>9.0</LangVersion>
+		<Nullable>enable</Nullable>
+		<AnalysisMode>All</AnalysisMode>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<NoWarn>1701;1702;SA0001;IDE0079</NoWarn>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+			<_Parameter1>FinalEngine.Tests</_Parameter1>
+		</AssemblyAttribute>
+	</ItemGroup>
+</Project>

--- a/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
+++ b/FinalEngine.Tests/Rendering/OpenGL/OpenGLRenderContextTests.cs
@@ -28,20 +28,6 @@ namespace FinalEngine.Tests.Rendering.OpenGL
         private OpenGLRenderContext renderContext;
 
         [Test]
-        public void ConstructorShouldInvokeBindVertexArrayWhenInvoked()
-        {
-            // Assert
-            this.invoker.Verify(x => x.BindVertexArray(VertexArrayID), Times.Once);
-        }
-
-        [Test]
-        public void ConstructorShouldInvokeGenVertexArrayWhenInvoked()
-        {
-            // Assert
-            this.invoker.Verify(x => x.GenVertexArray(), Times.Once);
-        }
-
-        [Test]
         public void ConstructorShouldInvokeLoadBindingsWhenInvoked()
         {
             // Assert

--- a/FinalEngine.sln
+++ b/FinalEngine.sln
@@ -46,6 +46,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extensions", "Extensions", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Extensions.Resources", "FinalEngine.Extensions.Resources\FinalEngine.Extensions.Resources.csproj", "{77328CBB-09C7-44E6-977F-C79812F6535A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Editor", "Editor", "{E10A7FCC-7937-4996-8F32-AB235F4CEDC0}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Editor.Common", "FinalEngine.Editor.Common\FinalEngine.Editor.Common.csproj", "{18E0B66D-BB85-47C4-ABEB-709CC39F54FD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Editor.ViewModels", "FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj", "{D514AB84-43ED-4ADF-AE04-CDB30A4D42E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Editor.Desktop", "FinalEngine.Editor.Desktop\FinalEngine.Editor.Desktop.csproj", "{5C6D465B-E5F4-4E0D-BC3A-4480E66E1515}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -100,6 +108,18 @@ Global
 		{77328CBB-09C7-44E6-977F-C79812F6535A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{77328CBB-09C7-44E6-977F-C79812F6535A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{77328CBB-09C7-44E6-977F-C79812F6535A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{18E0B66D-BB85-47C4-ABEB-709CC39F54FD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{18E0B66D-BB85-47C4-ABEB-709CC39F54FD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{18E0B66D-BB85-47C4-ABEB-709CC39F54FD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{18E0B66D-BB85-47C4-ABEB-709CC39F54FD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D514AB84-43ED-4ADF-AE04-CDB30A4D42E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D514AB84-43ED-4ADF-AE04-CDB30A4D42E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D514AB84-43ED-4ADF-AE04-CDB30A4D42E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D514AB84-43ED-4ADF-AE04-CDB30A4D42E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C6D465B-E5F4-4E0D-BC3A-4480E66E1515}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C6D465B-E5F4-4E0D-BC3A-4480E66E1515}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C6D465B-E5F4-4E0D-BC3A-4480E66E1515}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C6D465B-E5F4-4E0D-BC3A-4480E66E1515}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -117,6 +137,9 @@ Global
 		{976CD388-3DE5-4BA3-942F-C61C8D8F4C89} = {198F3F27-340D-4617-86BB-AE9D9D5494A2}
 		{6E9F635E-3A47-4778-9925-D5C53FD2C9AC} = {198F3F27-340D-4617-86BB-AE9D9D5494A2}
 		{77328CBB-09C7-44E6-977F-C79812F6535A} = {D9E1214F-1365-4DE5-9385-87A5FFE0F30D}
+		{18E0B66D-BB85-47C4-ABEB-709CC39F54FD} = {E10A7FCC-7937-4996-8F32-AB235F4CEDC0}
+		{D514AB84-43ED-4ADF-AE04-CDB30A4D42E2} = {E10A7FCC-7937-4996-8F32-AB235F4CEDC0}
+		{5C6D465B-E5F4-4E0D-BC3A-4480E66E1515} = {E10A7FCC-7937-4996-8F32-AB235F4CEDC0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A278B383-0D14-41B3-A71C-4505E1D503DF}


### PR DESCRIPTION
# Description

I added styling to the base of the editor application and a simple main menu.

## Dependencies

This PR introduces a new dependency:

- [MahApps.Metro 2.4.9](https://www.nuget.org/packages/MahApps.Metro/).

This is introduced to provide a Visual Studio like style to the editor. it can also be expanded at a later date to include theme configuration during runtime.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I tested this by running the editor, here is a screenshot of the result:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/50978201/155835498-052cdc95-3b63-4355-a31a-9387944aed83.png">

**Test Configuration**:
* Operating System: Windows 11 Enterprise
* Hardware: Intel i7-10750H @ 2.60GHz, 16 GB
* Toolchain: VS Professional 2022 17.0.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
