### PR TITLE
Example for Noggin_bops

### DIFF
--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -13,6 +13,9 @@ namespace FinalEngine.Editor.Desktop
     using FinalEngine.Editor.ViewModels.Interaction;
     using FinalEngine.IO;
     using FinalEngine.IO.Invocation;
+    using FinalEngine.Rendering;
+    using FinalEngine.Rendering.OpenGL;
+    using FinalEngine.Rendering.OpenGL.Invocation;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Microsoft.Toolkit.Mvvm.Messaging;
@@ -57,6 +60,9 @@ namespace FinalEngine.Editor.Desktop
             services.AddSingleton<IDirectoryInvoker, DirectoryInvoker>();
             services.AddSingleton<IPathInvoker, PathInvoker>();
             services.AddSingleton<IFileSystem, FileSystem>();
+
+            services.AddSingleton<IOpenGLInvoker, OpenGLInvoker>();
+            services.AddSingleton<IRenderDevice, OpenGLRenderDevice>();
 
             services.AddSingleton<IProjectFileHandler, ProjectFileHandler>();
 

--- a/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
+++ b/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
@@ -39,10 +39,12 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
+		<PackageReference Include="OpenTK.GLWpfControl" Version="4.2.2" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -53,6 +55,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj" />
+	  <ProjectReference Include="..\FinalEngine.Rendering.OpenGL\FinalEngine.Rendering.OpenGL.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FinalEngine.Editor.Desktop/Selectors/Docking/PanesTemplateSelector.cs
+++ b/FinalEngine.Editor.Desktop/Selectors/Docking/PanesTemplateSelector.cs
@@ -6,6 +6,7 @@ namespace FinalEngine.Editor.Desktop.Selectors.Docking
 {
     using System.Windows;
     using System.Windows.Controls;
+    using FinalEngine.Editor.ViewModels.Docking.Panes;
     using FinalEngine.Editor.ViewModels.Docking.Tools;
 
     /// <summary>
@@ -21,6 +22,8 @@ namespace FinalEngine.Editor.Desktop.Selectors.Docking
         ///   The project explorer template.
         /// </value>
         public DataTemplate? ProjectExplorerTemplate { get; set; }
+
+        public DataTemplate? SceneTemplate { get; set; }
 
         /// <summary>
         ///   When overridden in a derived class, returns a <see cref="System.Windows.DataTemplate"/> based on custom logic.
@@ -39,6 +42,11 @@ namespace FinalEngine.Editor.Desktop.Selectors.Docking
             if (item is IProjectExplorerViewModel)
             {
                 return this.ProjectExplorerTemplate;
+            }
+
+            if (item is ISceneViewModel)
+            {
+                return this.SceneTemplate;
             }
 
             return base.SelectTemplate(item, container);

--- a/FinalEngine.Editor.Desktop/Views/Docking/DockViewModel.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Docking/DockViewModel.xaml
@@ -5,6 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:init="clr-namespace:FinalEngine.Editor.Desktop.Initialization"
              xmlns:selectors="clr-namespace:FinalEngine.Editor.Desktop.Selectors.Docking"
+             xmlns:panes="clr-namespace:FinalEngine.Editor.Desktop.Views.Docking.Panes"
              xmlns:tools="clr-namespace:FinalEngine.Editor.Desktop.Views.Docking.Tools"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
@@ -28,6 +29,12 @@
                             <tools:ProjectExplorerView />
                         </DataTemplate>
                     </selectors:PanesTemplateSelector.ProjectExplorerTemplate>
+
+                    <selectors:PanesTemplateSelector.SceneTemplate>
+                        <DataTemplate>
+                            <panes:SceneView />
+                        </DataTemplate>
+                    </selectors:PanesTemplateSelector.SceneTemplate>
                 </selectors:PanesTemplateSelector>
             </DockingManager.LayoutItemTemplateSelector>
 

--- a/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml
@@ -1,0 +1,8 @@
+﻿<glwpf:GLWpfControl x:Class="FinalEngine.Editor.Desktop.Views.Docking.Panes.SceneView"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:glwpf="clr-namespace:OpenTK.Wpf;assembly=GLWpfControl"
+                    mc:Ignorable="d">
+</glwpf:GLWpfControl>

--- a/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml.cs
+++ b/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml.cs
@@ -1,0 +1,25 @@
+﻿namespace FinalEngine.Editor.Desktop.Views.Docking.Panes
+{
+    using OpenTK.Windowing.Common;
+    using OpenTK.Wpf;
+
+    /// <summary>
+    ///   Interaction logic for SceneView.xaml.
+    /// </summary>
+    public partial class SceneView : GLWpfControl
+    {
+        public SceneView()
+        {
+            this.InitializeComponent();
+
+            this.Start(new GLWpfControlSettings()
+            {
+                GraphicsContextFlags = ContextFlags.ForwardCompatible,
+                GraphicsProfile = ContextProfile.Core,
+                MajorVersion = 4,
+                MinorVersion = 5,
+                RenderContinuously = true,
+            });
+        }
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Docking/DockViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/DockViewModel.cs
@@ -35,7 +35,10 @@ namespace FinalEngine.Editor.ViewModels.Docking
                 viewModelFactory.CreateProjectExplorerViewModel(),
             };
 
-            this.Documents = new List<IPaneViewModel>();
+            this.Documents = new List<IPaneViewModel>()
+            {
+                viewModelFactory.CreateSceneViewModel(),
+            };
         }
 
         /// <summary>

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/ISceneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/ISceneViewModel.cs
@@ -1,0 +1,10 @@
+﻿// <copyright file="ISceneViewModel.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Docking.Panes
+{
+    public interface ISceneViewModel : IPaneViewModel
+    {
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/SceneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/SceneViewModel.cs
@@ -1,0 +1,14 @@
+﻿// <copyright file="SceneViewModel.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Docking.Panes
+{
+    public class SceneViewModel : PaneViewModelBase, ISceneViewModel
+    {
+        public SceneViewModel()
+        {
+            this.Title = "Scene View";
+        }
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Interaction/IViewModelFactory.cs
+++ b/FinalEngine.Editor.ViewModels/Interaction/IViewModelFactory.cs
@@ -5,6 +5,7 @@
 namespace FinalEngine.Editor.ViewModels.Interaction
 {
     using FinalEngine.Editor.ViewModels.Docking;
+    using FinalEngine.Editor.ViewModels.Docking.Panes;
     using FinalEngine.Editor.ViewModels.Docking.Tools;
 
     /// <summary>
@@ -35,5 +36,7 @@ namespace FinalEngine.Editor.ViewModels.Interaction
         ///   The newly created <see cref="IProjectExplorerViewModel"/>.
         /// </returns>
         IProjectExplorerViewModel CreateProjectExplorerViewModel();
+
+        ISceneViewModel CreateSceneViewModel();
     }
 }

--- a/FinalEngine.Editor.ViewModels/Interaction/ViewModelFactory.cs
+++ b/FinalEngine.Editor.ViewModels/Interaction/ViewModelFactory.cs
@@ -7,6 +7,7 @@ namespace FinalEngine.Editor.ViewModels.Interaction
     using System;
     using FinalEngine.Editor.Common.Services;
     using FinalEngine.Editor.ViewModels.Docking;
+    using FinalEngine.Editor.ViewModels.Docking.Panes;
     using FinalEngine.Editor.ViewModels.Docking.Tools;
     using Microsoft.Toolkit.Mvvm.Messaging;
 
@@ -17,6 +18,11 @@ namespace FinalEngine.Editor.ViewModels.Interaction
     public class ViewModelFactory : IViewModelFactory
     {
         /// <summary>
+        ///   The messanger.
+        /// </summary>
+        private readonly IMessenger messenger;
+
+        /// <summary>
         ///   The project file handler.
         /// </summary>
         private readonly IProjectFileHandler projectFileHandler;
@@ -25,11 +31,6 @@ namespace FinalEngine.Editor.ViewModels.Interaction
         ///   The user action requester.
         /// </summary>
         private readonly IUserActionRequester userActionRequester;
-
-        /// <summary>
-        ///   The messanger.
-        /// </summary>
-        private readonly IMessenger messenger;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="ViewModelFactory"/> class.
@@ -84,6 +85,11 @@ namespace FinalEngine.Editor.ViewModels.Interaction
         public IProjectExplorerViewModel CreateProjectExplorerViewModel()
         {
             return new ProjectExplorerViewModel(this.messenger);
+        }
+
+        public ISceneViewModel CreateSceneViewModel()
+        {
+            return new SceneViewModel();
         }
     }
 }


### PR DESCRIPTION
Here is where the user control is:

![image](https://user-images.githubusercontent.com/50978201/191274796-6856eac1-c81f-4ef9-8bcb-465b5198b6f8.png)

Build the solution, analyze and see the warnings listed in Visual Studio. Lastly, attempt to run `FinalEngine.Editor.Desktop` application to see an exception is thrown. The issue still persists when I upgrade to OpenTK 4.7.5.

![image](https://user-images.githubusercontent.com/50978201/191278464-7b29c9b0-1046-45df-ba00-236305c78e3c.png)
