### PR TITLE
FE-9 - Scene View

### DIFF
--- a/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
+++ b/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
@@ -35,5 +35,6 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\FinalEngine.IO\FinalEngine.IO.csproj" />
+	  <ProjectReference Include="..\FinalEngine.Rendering\FinalEngine.Rendering.csproj" />
 	</ItemGroup>
 </Project>

--- a/FinalEngine.Editor.Common/Services/Scenes/ISceneRenderer.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/ISceneRenderer.cs
@@ -1,0 +1,11 @@
+﻿// <copyright file="ISceneRenderer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Scenes
+{
+    public interface ISceneRenderer
+    {
+        void Render();
+    }
+}

--- a/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="SceneRenderer.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Scenes
+{
+    using System;
+    using System.Drawing;
+    using FinalEngine.Rendering;
+
+    public class SceneRenderer : ISceneRenderer
+    {
+        private readonly IRenderDevice renderDevice;
+
+        public SceneRenderer(IRenderDevice renderDevice)
+        {
+            this.renderDevice = renderDevice ?? throw new ArgumentNullException(nameof(renderDevice));
+        }
+
+        public void Render()
+        {
+            this.renderDevice.Clear(Color.CornflowerBlue);
+        }
+    }
+}

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -7,14 +7,19 @@ namespace FinalEngine.Editor.Desktop
     using System;
     using System.Windows;
     using FinalEngine.Editor.Common.Services;
+    using FinalEngine.Editor.Common.Services.Scenes;
     using FinalEngine.Editor.Desktop.Interaction;
     using FinalEngine.Editor.Desktop.Views;
     using FinalEngine.Editor.ViewModels;
     using FinalEngine.Editor.ViewModels.Interaction;
     using FinalEngine.IO;
     using FinalEngine.IO.Invocation;
+    using FinalEngine.Rendering;
+    using FinalEngine.Rendering.OpenGL;
+    using FinalEngine.Rendering.OpenGL.Invocation;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
+
     using Microsoft.Toolkit.Mvvm.Messaging;
 
     /// <summary>
@@ -57,6 +62,11 @@ namespace FinalEngine.Editor.Desktop
             services.AddSingleton<IDirectoryInvoker, DirectoryInvoker>();
             services.AddSingleton<IPathInvoker, PathInvoker>();
             services.AddSingleton<IFileSystem, FileSystem>();
+
+            services.AddSingleton<IOpenGLInvoker, OpenGLInvoker>();
+            services.AddSingleton<IRenderDevice, OpenGLRenderDevice>();
+
+            services.AddSingleton<ISceneRenderer, SceneRenderer>();
 
             services.AddSingleton<IProjectFileHandler, ProjectFileHandler>();
 

--- a/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
+++ b/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
@@ -30,6 +30,7 @@
 	<ItemGroup>
 		<PackageReference Include="Dirkster.AvalonDock" Version="4.70.1" />
 		<PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.70.1" />
+		<PackageReference Include="EventBinder" Version="2.5.0.1" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.9" />
 		<PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
 			<PrivateAssets>all</PrivateAssets>
@@ -39,10 +40,13 @@
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
+		<PackageReference Include="OpenTK.GLWpfControl" Version="4.2.2" />
+		<PackageReference Include="OpenTK.Windowing.Desktop" Version="4.7.5" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -53,6 +57,7 @@
 
 	<ItemGroup>
 	  <ProjectReference Include="..\FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj" />
+	  <ProjectReference Include="..\FinalEngine.Rendering.OpenGL\FinalEngine.Rendering.OpenGL.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/FinalEngine.Editor.Desktop/Selectors/Docking/PanesTemplateSelector.cs
+++ b/FinalEngine.Editor.Desktop/Selectors/Docking/PanesTemplateSelector.cs
@@ -6,6 +6,7 @@ namespace FinalEngine.Editor.Desktop.Selectors.Docking
 {
     using System.Windows;
     using System.Windows.Controls;
+    using FinalEngine.Editor.ViewModels.Docking.Panes;
     using FinalEngine.Editor.ViewModels.Docking.Tools;
 
     /// <summary>
@@ -21,6 +22,8 @@ namespace FinalEngine.Editor.Desktop.Selectors.Docking
         ///   The project explorer template.
         /// </value>
         public DataTemplate? ProjectExplorerTemplate { get; set; }
+
+        public DataTemplate? SceneTemplate { get; set; }
 
         /// <summary>
         ///   When overridden in a derived class, returns a <see cref="System.Windows.DataTemplate"/> based on custom logic.
@@ -39,6 +42,11 @@ namespace FinalEngine.Editor.Desktop.Selectors.Docking
             if (item is IProjectExplorerViewModel)
             {
                 return this.ProjectExplorerTemplate;
+            }
+
+            if (item is ISceneViewModel)
+            {
+                return this.SceneTemplate;
             }
 
             return base.SelectTemplate(item, container);

--- a/FinalEngine.Editor.Desktop/Styles/DocumentStyle.xaml
+++ b/FinalEngine.Editor.Desktop/Styles/DocumentStyle.xaml
@@ -1,7 +1,14 @@
 ﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:avalon="https://github.com/Dirkster99/AvalonDock">
     <Style x:Key="DocumentStyle" TargetType="{ x:Type LayoutItem}">
+        <Style.Resources>
+            <avalon:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
+        </Style.Resources>
         <Setter Property="Title" Value="{Binding Model.Title}" />
+        <Setter Property="CanClose" Value="False" />
         <Setter Property="ContentId" Value="{Binding Model.ContentID}" />
+        <Setter Property="IsSelected" Value="{Binding Model.IsSelected, Mode=TwoWay}" />
+        <Setter Property="IsActive" Value="{Binding Model.IsActive, Mode=TwoWay}" />
     </Style>
 </ResourceDictionary>

--- a/FinalEngine.Editor.Desktop/Views/Docking/DockViewModel.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Docking/DockViewModel.xaml
@@ -5,6 +5,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:init="clr-namespace:FinalEngine.Editor.Desktop.Initialization"
              xmlns:selectors="clr-namespace:FinalEngine.Editor.Desktop.Selectors.Docking"
+             xmlns:panes="clr-namespace:FinalEngine.Editor.Desktop.Views.Docking.Panes"
              xmlns:tools="clr-namespace:FinalEngine.Editor.Desktop.Views.Docking.Tools"
              mc:Ignorable="d"
              d:DesignHeight="450" d:DesignWidth="800">
@@ -28,6 +29,13 @@
                             <tools:ProjectExplorerView />
                         </DataTemplate>
                     </selectors:PanesTemplateSelector.ProjectExplorerTemplate>
+
+                    <!-- SCENE VIEW -->
+                    <selectors:PanesTemplateSelector.SceneTemplate>
+                        <DataTemplate>
+                            <panes:SceneView />
+                        </DataTemplate>
+                    </selectors:PanesTemplateSelector.SceneTemplate>
                 </selectors:PanesTemplateSelector>
             </DockingManager.LayoutItemTemplateSelector>
 

--- a/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml
@@ -1,0 +1,10 @@
+﻿<glwpf:GLWpfControl x:Class="FinalEngine.Editor.Desktop.Views.Docking.Panes.SceneView"
+                    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                    xmlns:eb="clr-namespace:EventBinder;assembly=EventBinder"
+                    xmlns:glwpf="clr-namespace:OpenTK.Wpf;assembly=GLWpfControl"
+                    mc:Ignorable="d"
+                    Render="{eb:EventBinding RenderCommand.Execute, `null`}">
+</glwpf:GLWpfControl>

--- a/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml.cs
+++ b/FinalEngine.Editor.Desktop/Views/Docking/Panes/SceneView.xaml.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="SceneView.xaml.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Desktop.Views.Docking.Panes
+{
+    using OpenTK.Windowing.Common;
+    using OpenTK.Wpf;
+
+    /// <summary>
+    ///   Interaction logic for SceneView.xaml.
+    /// </summary>
+    public partial class SceneView : GLWpfControl
+    {
+        /// <summary>
+        ///   Initializes a new instance of the <see cref="SceneView"/> class.
+        /// </summary>
+        public SceneView()
+        {
+            this.InitializeComponent();
+
+            this.Start(new GLWpfControlSettings()
+            {
+                MajorVersion = 4,
+                MinorVersion = 6,
+                GraphicsContextFlags = ContextFlags.ForwardCompatible,
+                GraphicsProfile = ContextProfile.Core,
+                RenderContinuously = true,
+            });
+        }
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Docking/DockViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/DockViewModel.cs
@@ -35,7 +35,10 @@ namespace FinalEngine.Editor.ViewModels.Docking
                 viewModelFactory.CreateProjectExplorerViewModel(),
             };
 
-            this.Documents = new List<IPaneViewModel>();
+            this.Documents = new List<IPaneViewModel>()
+            {
+                viewModelFactory.CreateSceneViewModel(),
+            };
         }
 
         /// <summary>

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/ISceneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/ISceneViewModel.cs
@@ -1,0 +1,13 @@
+﻿// <copyright file="ISceneViewModel.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Docking.Panes
+{
+    using System.Windows.Input;
+
+    public interface ISceneViewModel : IPaneViewModel
+    {
+        ICommand RenderCommand { get; }
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/SceneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/SceneViewModel.cs
@@ -1,0 +1,36 @@
+﻿// <copyright file="SceneViewModel.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Docking.Panes
+{
+    using System;
+    using System.Windows.Input;
+    using FinalEngine.Editor.Common.Services.Scenes;
+    using Microsoft.Toolkit.Mvvm.Input;
+
+    public class SceneViewModel : PaneViewModelBase, ISceneViewModel
+    {
+        private readonly ISceneRenderer sceneRenderer;
+
+        private ICommand? renderCommand;
+
+        public SceneViewModel(ISceneRenderer sceneRenderer)
+        {
+            this.sceneRenderer = sceneRenderer ?? throw new ArgumentNullException(nameof(sceneRenderer));
+
+            this.Title = "Scene View";
+            this.ContentID = "SceneViewPane";
+        }
+
+        public ICommand RenderCommand
+        {
+            get { return this.renderCommand ??= new RelayCommand(this.Render); }
+        }
+
+        private void Render()
+        {
+            this.sceneRenderer.Render();
+        }
+    }
+}

--- a/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
+++ b/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
@@ -37,5 +37,6 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\FinalEngine.Editor.Common\FinalEngine.Editor.Common.csproj" />
 	  <ProjectReference Include="..\FinalEngine.IO\FinalEngine.IO.csproj" />
+	  <ProjectReference Include="..\FinalEngine.Rendering\FinalEngine.Rendering.csproj" />
 	</ItemGroup>
 </Project>

--- a/FinalEngine.Editor.ViewModels/Interaction/IViewModelFactory.cs
+++ b/FinalEngine.Editor.ViewModels/Interaction/IViewModelFactory.cs
@@ -5,6 +5,7 @@
 namespace FinalEngine.Editor.ViewModels.Interaction
 {
     using FinalEngine.Editor.ViewModels.Docking;
+    using FinalEngine.Editor.ViewModels.Docking.Panes;
     using FinalEngine.Editor.ViewModels.Docking.Tools;
 
     /// <summary>
@@ -35,5 +36,7 @@ namespace FinalEngine.Editor.ViewModels.Interaction
         ///   The newly created <see cref="IProjectExplorerViewModel"/>.
         /// </returns>
         IProjectExplorerViewModel CreateProjectExplorerViewModel();
+
+        ISceneViewModel CreateSceneViewModel();
     }
 }

--- a/FinalEngine.Editor.ViewModels/Interaction/ViewModelFactory.cs
+++ b/FinalEngine.Editor.ViewModels/Interaction/ViewModelFactory.cs
@@ -6,7 +6,9 @@ namespace FinalEngine.Editor.ViewModels.Interaction
 {
     using System;
     using FinalEngine.Editor.Common.Services;
+    using FinalEngine.Editor.Common.Services.Scenes;
     using FinalEngine.Editor.ViewModels.Docking;
+    using FinalEngine.Editor.ViewModels.Docking.Panes;
     using FinalEngine.Editor.ViewModels.Docking.Tools;
     using Microsoft.Toolkit.Mvvm.Messaging;
 
@@ -17,19 +19,21 @@ namespace FinalEngine.Editor.ViewModels.Interaction
     public class ViewModelFactory : IViewModelFactory
     {
         /// <summary>
+        ///   The messanger.
+        /// </summary>
+        private readonly IMessenger messenger;
+
+        /// <summary>
         ///   The project file handler.
         /// </summary>
         private readonly IProjectFileHandler projectFileHandler;
+
+        private readonly ISceneRenderer sceneRenderer;
 
         /// <summary>
         ///   The user action requester.
         /// </summary>
         private readonly IUserActionRequester userActionRequester;
-
-        /// <summary>
-        ///   The messanger.
-        /// </summary>
-        private readonly IMessenger messenger;
 
         /// <summary>
         ///   Initializes a new instance of the <see cref="ViewModelFactory"/> class.
@@ -46,11 +50,16 @@ namespace FinalEngine.Editor.ViewModels.Interaction
         /// <exception cref="ArgumentNullException">
         ///   The specified <paramref name="userActionRequester"/> or <paramref name="projectFileHandler"/> parameter cannot be null.
         /// </exception>
-        public ViewModelFactory(IUserActionRequester userActionRequester, IProjectFileHandler projectFileHandler, IMessenger messenger)
+        public ViewModelFactory(
+            IUserActionRequester userActionRequester,
+            IProjectFileHandler projectFileHandler,
+            IMessenger messenger,
+            ISceneRenderer sceneRenderer)
         {
             this.userActionRequester = userActionRequester ?? throw new ArgumentNullException(nameof(userActionRequester));
             this.projectFileHandler = projectFileHandler ?? throw new ArgumentNullException(nameof(projectFileHandler));
             this.messenger = messenger ?? throw new ArgumentNullException(nameof(messenger));
+            this.sceneRenderer = sceneRenderer ?? throw new ArgumentNullException(nameof(sceneRenderer));
         }
 
         /// <summary>
@@ -84,6 +93,11 @@ namespace FinalEngine.Editor.ViewModels.Interaction
         public IProjectExplorerViewModel CreateProjectExplorerViewModel()
         {
             return new ProjectExplorerViewModel(this.messenger);
+        }
+
+        public ISceneViewModel CreateSceneViewModel()
+        {
+            return new SceneViewModel(this.sceneRenderer);
         }
     }
 }

--- a/FinalEngine.Launching/FinalEngine.Launching.csproj
+++ b/FinalEngine.Launching/FinalEngine.Launching.csproj
@@ -20,10 +20,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTK.Core" Version="4.7.1" />
-    <PackageReference Include="OpenTK.Graphics" Version="4.7.1" />
-    <PackageReference Include="OpenTK.Mathematics" Version="4.7.1" />
-    <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.1" />
+    <PackageReference Include="OpenTK.Core" Version="4.7.5" />
+    <PackageReference Include="OpenTK.Graphics" Version="4.7.5" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
+    <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
+++ b/FinalEngine.Platform.Desktop/FinalEngine.Platform.Desktop.csproj
@@ -20,10 +20,10 @@
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="OpenTK.Core" Version="4.7.1" />
-	  <PackageReference Include="OpenTK.Mathematics" Version="4.7.1" />
-	  <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.1" />
-	  <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.7.1" />
+	  <PackageReference Include="OpenTK.Core" Version="4.7.5" />
+	  <PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
+	  <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.5" />
+	  <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.7.5" />
 	  <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FinalEngine.Rendering.OpenGL/FinalEngine.Rendering.OpenGL.csproj
+++ b/FinalEngine.Rendering.OpenGL/FinalEngine.Rendering.OpenGL.csproj
@@ -20,10 +20,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="OpenTK.Core" Version="4.7.1" />
-    <PackageReference Include="OpenTK.Graphics" Version="4.7.1" />
-    <PackageReference Include="OpenTK.Mathematics" Version="4.7.1" />
-    <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.1" />
+    <PackageReference Include="OpenTK.Core" Version="4.7.5" />
+    <PackageReference Include="OpenTK.Graphics" Version="4.7.5" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
+    <PackageReference Include="OpenTK.Windowing.Common" Version="4.7.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/FinalEngine.Tests/FinalEngine.Tests.csproj
+++ b/FinalEngine.Tests/FinalEngine.Tests.csproj
@@ -24,8 +24,8 @@
 		<PackageReference Include="NUnit" Version="3.13.2" />
 		<PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-		<PackageReference Include="OpenTK.Core" Version="4.7.1" />
-		<PackageReference Include="OpenTK.Mathematics" Version="4.7.1" />
+		<PackageReference Include="OpenTK.Core" Version="4.7.5" />
+		<PackageReference Include="OpenTK.Mathematics" Version="4.7.5" />
 		<PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Description

This PR introduces a scene view within the editor. It's basically just a way to ensure that OpenGL calls can be executed from within the editor.

- Created an `ISceneRenderer` service interface and implementation that will simply clear the scene to a blue colour.
- Added missing configuration property to `DocumentStyle`.
- Created `SceneView` (and corresponding view model) that is attached to the `DockView`.
- Currently the `GLWpfControl` is using `EventBinder` to hook onto the `Render` event. This will change soon and we can remove the dependency.

Fixes [FE-9](https://mantanimus.atlassian.net/browse/FE-9).

## Dependencies

- [GLWpfControl 4.2.2](https://www.nuget.org/packages/OpenTK.GLWpfControl/).
- [OpenTK 4.7.5](https://www.nuget.org/packages/OpenTK/).
- [System.Runtime.CompilerServices.Unsafe 6.0.0](https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/).
- [EventBinder 2.5.0.1](https://www.nuget.org/packages/EventBinder/2.5.0.1).

## Type of change

- [x] New feature (non-breaking change which adds functionality).

This feature is part of the [Application Editor](https://mantanimus.atlassian.net/browse/FE-3) epic.

## How Has This Been Tested?

I tested this by simply cleaning, rebuilding and running the _Application Editor_ then ensuring that the screen has been cleared to a blue colour. This is the amount of testing that is required for the ticket as other tickets within the epic will be used to address some pitfalls such as not considering the camera projection within the editor.

**Test Configuration**:
* Operating System: Windows 10 Home.
* Hardware: Intel i7-6700HQ CPU @ 2.60GHz, 16GB RAM, GTX 950M.
* Toolchain: VS Community 2022.

## Possible Issues

This ticket has introduced (or brought to light to the following issues):

- [FE-59](https://mantanimus.atlassian.net/browse/FE-59)
- [FE-60](https://mantanimus.atlassian.net/browse/FE-60)
- [FE-61](https://mantanimus.atlassian.net/browse/FE-61).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
