### PR TITLE
FE-23 - Add support for logging to output files.

### DIFF
--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -67,7 +67,7 @@ namespace FinalEngine.Editor.Desktop
             var services = new ServiceCollection();
             var configuration = BuildConfiguration();
 
-            services.AddLogging(x => x.AddConsole().AddFile(configuration.GetSection("Logging")));
+            services.AddLogging(x => x.AddConsole().AddFile(configuration.GetSection("LoggingOptions")));
             services.AddSingleton<IMessenger>(WeakReferenceMessenger.Default);
 
             services.AddSingleton<IFileInvoker, FileInvoker>();

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -5,6 +5,7 @@
 namespace FinalEngine.Editor.Desktop
 {
     using System;
+    using System.IO;
     using System.Windows;
     using FinalEngine.Editor.Common.Services.Factories;
     using FinalEngine.Editor.Common.Services.Projects;
@@ -18,6 +19,7 @@ namespace FinalEngine.Editor.Desktop
     using FinalEngine.Rendering;
     using FinalEngine.Rendering.OpenGL;
     using FinalEngine.Rendering.OpenGL.Invocation;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
 
@@ -46,6 +48,14 @@ namespace FinalEngine.Editor.Desktop
             view.ShowDialog();
         }
 
+        private static IConfiguration BuildConfiguration()
+        {
+            return new ConfigurationBuilder()
+                .SetBasePath(Directory.GetCurrentDirectory())
+                .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
+                .Build();
+        }
+
         /// <summary>
         ///   Configures the services to be consumed by the application.
         /// </summary>
@@ -55,8 +65,9 @@ namespace FinalEngine.Editor.Desktop
         private static IServiceProvider ConfigureServices()
         {
             var services = new ServiceCollection();
+            var configuration = BuildConfiguration();
 
-            services.AddLogging(x => x.AddConsole());
+            services.AddLogging(x => x.AddConsole().AddFile(configuration.GetSection("Logging")));
             services.AddSingleton<IMessenger>(WeakReferenceMessenger.Default);
 
             services.AddSingleton<IFileInvoker, FileInvoker>();

--- a/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
+++ b/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
@@ -41,12 +41,15 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
+		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
 		<PackageReference Include="Ookii.Dialogs.Wpf" Version="5.0.1" />
 		<PackageReference Include="OpenTK.GLWpfControl" Version="4.2.2" />
 		<PackageReference Include="OpenTK.Windowing.Desktop" Version="4.7.5" />
+		<PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -96,6 +99,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <None Update="appsettings.json">
+	    <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
 	  <None Update="Properties\Settings.settings">
 	    <Generator>SettingsSingleFileGenerator</Generator>
 	    <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/FinalEngine.Editor.Desktop/appsettings.json
+++ b/FinalEngine.Editor.Desktop/appsettings.json
@@ -1,6 +1,8 @@
 ﻿{
   "LoggingOptions": {
     "PathFormat": "Logs/FinalEnine.Editor.Desktop - {Date}.txt",
-    "LogLevel": "Debug"
+    "LogLevel": {
+      "Default": "Error"
+    }
   }
 }

--- a/FinalEngine.Editor.Desktop/appsettings.json
+++ b/FinalEngine.Editor.Desktop/appsettings.json
@@ -1,0 +1,6 @@
+﻿{
+  "LoggingOptions": {
+    "PathFormat": "Logs/FinalEnine.Editor.Desktop - {Date}.txt",
+    "LogLevel": "Debug"
+  }
+}


### PR DESCRIPTION
# Description

- Configurations are now able to be added to the engine. This will definitely come in handy as the project grows.
- Logs can now be outputted to a file (named: "_FinalEngine.Editor.Desktop - {Date}_".

Fixes FE-23

## Dependencies

- [Microsoft.Extensions.Configuration.Json 6.0.0](https://www.nuget.org/packages/Microsoft.Extensions.Configuration.Json/).
- [Microsoft.Extensions.Options.ConfigurationExtensions 6.0.0](https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions/).
- [Serilog.Extensions.Logging.File](https://www.nuget.org/packages/serilog.extensions.logging.file).

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I tested this by running the editor and ensuring that logs are outputted to the correct file. I also made sure that the `LogLevel` was taken into account and only logs of the level specified and above will be logged.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ @ 2.60GHz, 16GB RAM, GTX-950M
* Toolchain: VS Community 2022

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] My changes generate no new warnings
