### PR TITLE
[FEATURE] Shader Resource Loader

### DIFF
--- a/FinalEngine.Examples.Game/Program.cs
+++ b/FinalEngine.Examples.Game/Program.cs
@@ -179,6 +179,7 @@ internal static class Program
             window.ProcessEvents();
         }
 
+        drawer.Dispose();
         mesh.Dispose();
         shaderProgram.Dispose();
         fragmentShader.Dispose();

--- a/FinalEngine.Examples.Game/Program.cs
+++ b/FinalEngine.Examples.Game/Program.cs
@@ -62,7 +62,8 @@ internal static class Program
 
         var file = new FileInvoker();
         var directory = new DirectoryInvoker();
-        var fileSystem = new FileSystem(file, directory);
+        var path = new PathInvoker();
+        var fileSystem = new FileSystem(file, directory, path);
 
         var keyboardDevice = new OpenTKKeyboardDevice(nativeWindow);
         var keyboard = new Keyboard(keyboardDevice);

--- a/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
+++ b/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
@@ -91,7 +91,7 @@ public sealed class ShaderResourceLoader : ResourceLoaderBase<IShader>
     /// <returns>
     /// The pipeline target that relates to the specified <paramref name="extension"/>.
     /// </returns>
-    private PipelineTarget GetPipelineTarget(string extension)
+    private PipelineTarget GetPipelineTarget(string? extension)
     {
         return extension switch
         {

--- a/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
+++ b/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
@@ -71,7 +71,7 @@ public sealed class ShaderResourceLoader : ResourceLoaderBase<IShader>
             throw new FileNotFoundException($"The specified {nameof(filePath)} couldn't be located.", filePath);
         }
 
-        var target = this.GetPipelineTarget(Path.GetExtension(filePath));
+        var target = this.GetPipelineTarget(this.fileSystem.GetExtension(filePath));
 
         using (var stream = this.fileSystem.OpenFile(filePath, FileAccessMode.Read))
         {

--- a/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
+++ b/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
@@ -1,0 +1,58 @@
+// <copyright file="ShaderResourceLoader.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Extensions.Resources.Loaders.Shaders;
+
+using System;
+using System.IO;
+using FinalEngine.IO;
+using FinalEngine.Rendering;
+using FinalEngine.Rendering.Pipeline;
+using FinalEngine.Resources;
+
+public sealed class ShaderResourceLoader : ResourceLoaderBase<IShader>
+{
+    private readonly IGPUResourceFactory factory;
+
+    private readonly IFileSystem fileSystem;
+
+    public ShaderResourceLoader(IGPUResourceFactory factory, IFileSystem fileSystem)
+    {
+        this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
+        this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
+    }
+
+    public override IShader LoadResource(string filePath)
+    {
+        if (string.IsNullOrWhiteSpace(filePath))
+        {
+            throw new ArgumentNullException(nameof(filePath));
+        }
+
+        if (!this.fileSystem.FileExists(filePath))
+        {
+            throw new FileNotFoundException($"The specified {nameof(filePath)} couldn't be located.", filePath);
+        }
+
+        var target = this.GetPipelineTarget(Path.GetExtension(filePath));
+
+        using (var stream = this.fileSystem.OpenFile(filePath, FileAccessMode.Read))
+        {
+            using (var reader = new StreamReader(stream))
+            {
+                return this.factory.CreateShader(target, reader.ReadToEnd());
+            }
+        }
+    }
+
+    private PipelineTarget GetPipelineTarget(string extension)
+    {
+        return extension switch
+        {
+            ".vs" or ".vert" => PipelineTarget.Vertex,
+            ".fs" or ".frag" => PipelineTarget.Fragment,
+            _ => throw new NotSupportedException($"The specified {nameof(extension)} is not supported by the {nameof(ShaderResourceLoader)}."),
+        };
+    }
+}

--- a/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
+++ b/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
@@ -11,18 +11,54 @@ using FinalEngine.Rendering;
 using FinalEngine.Rendering.Pipeline;
 using FinalEngine.Resources;
 
+/// <summary>
+/// Provides a resource loader that can load an <see cref="IShader"/> resource.
+/// </summary>
 public sealed class ShaderResourceLoader : ResourceLoaderBase<IShader>
 {
+    /// <summary>
+    /// The GPU resource factory, used to load shaders into memory.
+    /// </summary>
     private readonly IGPUResourceFactory factory;
 
+    /// <summary>
+    /// The file system, used to load shader source code into memory.
+    /// </summary>
     private readonly IFileSystem fileSystem;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ShaderResourceLoader"/> class.
+    /// </summary>
+    /// <param name="factory">
+    /// The GPU resource factory, used to load shaders into memory.
+    /// </param>
+    /// <param name="fileSystem">
+    /// The file system, used to load shader source code into memory.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="factory"/> or <paramref name="fileSystem"/> parameter cannot be null.
+    /// </exception>
     public ShaderResourceLoader(IGPUResourceFactory factory, IFileSystem fileSystem)
     {
         this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
         this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));
     }
 
+    /// <summary>
+    /// Loads an <see cref="IShader"/> resource from the specified <paramref name="filePath" />.
+    /// </summary>
+    /// <param name="filePath">
+    /// The file path to load the resource.
+    /// </param>
+    /// <returns>
+    /// The newly loaded resource.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="filePath"/> parameter cannot be null.
+    /// </exception>
+    /// <exception cref="FileNotFoundException">
+    /// The specified <paramref name="filePath"/> couldn't be located.
+    /// </exception>
     public override IShader LoadResource(string filePath)
     {
         if (string.IsNullOrWhiteSpace(filePath))
@@ -46,6 +82,15 @@ public sealed class ShaderResourceLoader : ResourceLoaderBase<IShader>
         }
     }
 
+    /// <summary>
+    /// Gets the pipeline target based on the specified file <paramref name="extension"/>.
+    /// </summary>
+    /// <param name="extension">
+    /// The file extension (including the period).
+    /// </param>
+    /// <returns>
+    /// The pipeline target that relates to the specified <paramref name="extension"/>.
+    /// </returns>
     private PipelineTarget GetPipelineTarget(string extension)
     {
         return extension switch

--- a/FinalEngine.IO/FileSystem.cs
+++ b/FinalEngine.IO/FileSystem.cs
@@ -448,7 +448,7 @@ public class FileSystem : IFileSystem
     /// <exception cref="ArgumentException">
     /// The specified <paramref name="path"/> parameter cannot be null, empty or consist of only whitespace characters.
     /// </exception>
-    public string GetExtension(string path)
+    public string? GetExtension(string path)
     {
         if (string.IsNullOrWhiteSpace(path))
         {

--- a/FinalEngine.IO/FileSystem.cs
+++ b/FinalEngine.IO/FileSystem.cs
@@ -30,6 +30,11 @@ public class FileSystem : IFileSystem
     private readonly IFileInvoker file;
 
     /// <summary>
+    /// The path invoker.
+    /// </summary>
+    private readonly IPathInvoker path;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="FileSystem"/> class.
     /// </summary>
     /// <param name="file">
@@ -38,13 +43,17 @@ public class FileSystem : IFileSystem
     /// <param name="directory">
     /// Specifies an <see cref="IDirectoryInvoker"/> that represents the invoker used to handle directory operations.
     /// </param>
+    /// <param name="path">
+    /// Specifies an <see cref="IPathInvoker"/> that represents the invoker used to handle path operations.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// The specified <paramref name="file"/> or <paramref name="directory"/> parameter cannot be null.
     /// </exception>
-    public FileSystem(IFileInvoker file, IDirectoryInvoker directory)
+    public FileSystem(IFileInvoker file, IDirectoryInvoker directory, IPathInvoker path)
     {
         this.file = file ?? throw new ArgumentNullException(nameof(file));
         this.directory = directory ?? throw new ArgumentNullException(nameof(directory));
+        this.path = path ?? throw new ArgumentNullException(nameof(path));
     }
 
     /// <inheritdoc/>
@@ -425,6 +434,28 @@ public class FileSystem : IFileSystem
         }
 
         return this.file.Exists(path);
+    }
+
+    /// <summary>
+    /// Gets the extension from the file at the specified <paramref name="path" /> (including the period).
+    /// </summary>
+    /// <param name="path">
+    /// The path of the file.
+    /// </param>
+    /// <returns>
+    /// The extension of the file at the specified <paramref name="path" /> (including the period).
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// The specified <paramref name="path"/> parameter cannot be null, empty or consist of only whitespace characters.
+    /// </exception>
+    public string GetExtension(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            throw new ArgumentException($"The specified {nameof(path)} parameter cannot be null, empty or consist of only whitespace characters.", nameof(path));
+        }
+
+        return this.path.GetExtension(path);
     }
 
     /// <inheritdoc/>

--- a/FinalEngine.IO/IFileSystem.cs
+++ b/FinalEngine.IO/IFileSystem.cs
@@ -69,6 +69,17 @@ public interface IFileSystem
     bool FileExists(string path);
 
     /// <summary>
+    /// Gets the extension from the file at the specified <paramref name="path"/> (including the period).
+    /// </summary>
+    /// <param name="path">
+    /// The path of the file.
+    /// </param>
+    /// <returns>
+    /// The extension of the file at the specified <paramref name="path"/> (including the period).
+    /// </returns>
+    string GetExtension(string path);
+
+    /// <summary>
     /// Opens a file located at the specified <paramref name="path"/>, with the specified <paramref name="mode"/>.
     /// </summary>
     /// <param name="path">

--- a/FinalEngine.IO/IFileSystem.cs
+++ b/FinalEngine.IO/IFileSystem.cs
@@ -77,7 +77,7 @@ public interface IFileSystem
     /// <returns>
     /// The extension of the file at the specified <paramref name="path"/> (including the period).
     /// </returns>
-    string GetExtension(string path);
+    string? GetExtension(string path);
 
     /// <summary>
     /// Opens a file located at the specified <paramref name="path"/>, with the specified <paramref name="mode"/>.

--- a/FinalEngine.IO/Invocation/IPathInvoker.cs
+++ b/FinalEngine.IO/Invocation/IPathInvoker.cs
@@ -1,0 +1,16 @@
+// <copyright file="IPathInvoker.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.IO.Invocation;
+
+using System.IO;
+
+/// <summary>
+/// Defines an interface that provides methods for invocation of the <see cref="Path"/> class.
+/// </summary>
+public interface IPathInvoker
+{
+    /// <inheritdoc cref="Path.GetExtension(string?)"/>
+    string? GetExtension(string? path);
+}

--- a/FinalEngine.IO/Invocation/PathInvoker.cs
+++ b/FinalEngine.IO/Invocation/PathInvoker.cs
@@ -1,0 +1,20 @@
+// <copyright file="PathInvoker.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.IO.Invocation;
+
+using System.IO;
+
+/// <summary>
+/// Provides an implementation of an <see cref="IPathInvoker"/>.
+/// </summary>
+/// <seealso cref="IPathInvoker" />
+public sealed class PathInvoker : IPathInvoker
+{
+    /// <inheritdoc/>
+    public string? GetExtension(string? path)
+    {
+        return Path.GetExtension(path);
+    }
+}

--- a/FinalEngine.Rendering/FinalEngine.Rendering.csproj
+++ b/FinalEngine.Rendering/FinalEngine.Rendering.csproj
@@ -42,6 +42,12 @@
     <None Update="Resources\Shaders\forward-geometry.vert">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Shaders\sprite-geometry.frag">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Resources\Shaders\sprite-geometry.vert">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Textures\default_diffuse.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/FinalEngine.Rendering/Resources/Shaders/sprite-geometry.frag
+++ b/FinalEngine.Rendering/Resources/Shaders/sprite-geometry.frag
@@ -1,0 +1,52 @@
+#version 460
+
+layout (location = 0) in vec4 in_color;
+layout (location = 1) in vec2 in_texCoord;
+layout (location = 2) in float in_textureID;
+
+out vec4 out_color;
+
+uniform sampler2D u_textures[32];
+
+void main()
+{
+    vec4 color = in_color;
+
+    switch(int(in_textureID))
+    {
+        case 0: color *= texture(u_textures[0], in_texCoord); break;
+        case 1: color *= texture(u_textures[1], in_texCoord); break;
+        case 2: color *= texture(u_textures[2], in_texCoord); break;
+        case 3: color *= texture(u_textures[3], in_texCoord); break;
+        case 4: color *= texture(u_textures[4], in_texCoord); break;
+        case 5: color *= texture(u_textures[5], in_texCoord); break;
+        case 6: color *= texture(u_textures[6], in_texCoord); break;
+        case 7: color *= texture(u_textures[7], in_texCoord); break;
+        case 8: color *= texture(u_textures[8], in_texCoord); break;
+        case 9: color *= texture(u_textures[9], in_texCoord); break;
+        case 10: color *= texture(u_textures[10], in_texCoord); break;
+        case 11: color *= texture(u_textures[11], in_texCoord); break;
+        case 12: color *= texture(u_textures[12], in_texCoord); break;
+        case 13: color *= texture(u_textures[13], in_texCoord); break;
+        case 14: color *= texture(u_textures[14], in_texCoord); break;
+        case 15: color *= texture(u_textures[15], in_texCoord); break;
+        case 16: color *= texture(u_textures[16], in_texCoord); break;
+        case 17: color *= texture(u_textures[17], in_texCoord); break;
+        case 18: color *= texture(u_textures[18], in_texCoord); break;
+        case 19: color *= texture(u_textures[19], in_texCoord); break;
+        case 20: color *= texture(u_textures[20], in_texCoord); break;
+        case 21: color *= texture(u_textures[21], in_texCoord); break;
+        case 22: color *= texture(u_textures[22], in_texCoord); break;
+        case 23: color *= texture(u_textures[23], in_texCoord); break;
+        case 24: color *= texture(u_textures[24], in_texCoord); break;
+        case 25: color *= texture(u_textures[25], in_texCoord); break;
+        case 26: color *= texture(u_textures[26], in_texCoord); break;
+        case 27: color *= texture(u_textures[27], in_texCoord); break;
+        case 28: color *= texture(u_textures[28], in_texCoord); break;
+        case 29: color *= texture(u_textures[29], in_texCoord); break;
+        case 30: color *= texture(u_textures[30], in_texCoord); break;
+        case 31: color *= texture(u_textures[31], in_texCoord); break;
+    }
+
+    out_color = color;
+}

--- a/FinalEngine.Rendering/Resources/Shaders/sprite-geometry.vert
+++ b/FinalEngine.Rendering/Resources/Shaders/sprite-geometry.vert
@@ -1,0 +1,22 @@
+#version 460
+
+layout(location = 0) in vec2 in_position;
+layout(location = 1) in vec4 in_color;
+layout(location = 2) in vec2 in_texCoord;
+layout(location = 3) in float in_textureID;
+
+layout(location = 0) out vec4 out_color;
+layout(location = 1) out vec2 out_texCoord;
+layout(location = 2) out float out_textureID;
+
+uniform mat4 u_projection;
+uniform mat4 u_transform;
+
+void main()
+{
+    out_color = in_color;
+    out_texCoord = vec2(in_texCoord.x, 1.0 - in_texCoord.y);;
+    out_textureID = in_textureID;
+
+    gl_Position = u_projection * u_transform * vec4(in_position, 0.0, 1.0);
+}

--- a/FinalEngine.Rendering/SpriteDrawer.cs
+++ b/FinalEngine.Rendering/SpriteDrawer.cs
@@ -322,13 +322,13 @@ public class SpriteDrawer : ISpriteDrawer, IDisposable
 
             if (this.vertexShader != null)
             {
-                this.vertexShader.Dispose();
+                ResourceManager.Instance.UnloadResource(this.vertexShader);
                 this.vertexShader = null;
             }
 
             if (this.fragmentShader != null)
             {
-                this.fragmentShader.Dispose();
+                ResourceManager.Instance.UnloadResource(this.fragmentShader);
                 this.fragmentShader = null;
             }
         }

--- a/FinalEngine.Rendering/SpriteDrawer.cs
+++ b/FinalEngine.Rendering/SpriteDrawer.cs
@@ -10,6 +10,7 @@ using System.Numerics;
 using FinalEngine.Rendering.Buffers;
 using FinalEngine.Rendering.Pipeline;
 using FinalEngine.Rendering.Textures;
+using FinalEngine.Resources;
 
 /// <summary>
 ///   Provides a standard implementation of an <see cref="ISpriteDrawer"/>, which assumes batch rendering.
@@ -27,63 +28,6 @@ public class SpriteDrawer : ISpriteDrawer, IDisposable
     ///   The texture binder.
     /// </summary>
     private readonly ITextureBinder binder;
-
-    /// <summary>
-    ///   The fragment shader source.
-    /// </summary>
-    private readonly string fragmentShaderSource =
-        @"#version 460
-
-              layout (location = 0) in vec4 in_color;
-              layout (location = 1) in vec2 in_texCoord;
-              layout (location = 2) in float in_textureID;
-
-              out vec4 out_color;
-
-              uniform sampler2D u_textures[32];
-
-              void main()
-              {
-                  vec4 color = in_color;
-
-                  switch(int(in_textureID))
-                  {
-                      case 0: color *= texture(u_textures[0], in_texCoord); break;
-                      case 1: color *= texture(u_textures[1], in_texCoord); break;
-                      case 2: color *= texture(u_textures[2], in_texCoord); break;
-                      case 3: color *= texture(u_textures[3], in_texCoord); break;
-                      case 4: color *= texture(u_textures[4], in_texCoord); break;
-                      case 5: color *= texture(u_textures[5], in_texCoord); break;
-                      case 6: color *= texture(u_textures[6], in_texCoord); break;
-                      case 7: color *= texture(u_textures[7], in_texCoord); break;
-                      case 8: color *= texture(u_textures[8], in_texCoord); break;
-                      case 9: color *= texture(u_textures[9], in_texCoord); break;
-                      case 10: color *= texture(u_textures[10], in_texCoord); break;
-                      case 11: color *= texture(u_textures[11], in_texCoord); break;
-                      case 12: color *= texture(u_textures[12], in_texCoord); break;
-                      case 13: color *= texture(u_textures[13], in_texCoord); break;
-                      case 14: color *= texture(u_textures[14], in_texCoord); break;
-                      case 15: color *= texture(u_textures[15], in_texCoord); break;
-                      case 16: color *= texture(u_textures[16], in_texCoord); break;
-                      case 17: color *= texture(u_textures[17], in_texCoord); break;
-                      case 18: color *= texture(u_textures[18], in_texCoord); break;
-                      case 19: color *= texture(u_textures[19], in_texCoord); break;
-                      case 20: color *= texture(u_textures[20], in_texCoord); break;
-                      case 21: color *= texture(u_textures[21], in_texCoord); break;
-                      case 22: color *= texture(u_textures[22], in_texCoord); break;
-                      case 23: color *= texture(u_textures[23], in_texCoord); break;
-                      case 24: color *= texture(u_textures[24], in_texCoord); break;
-                      case 25: color *= texture(u_textures[25], in_texCoord); break;
-                      case 26: color *= texture(u_textures[26], in_texCoord); break;
-                      case 27: color *= texture(u_textures[27], in_texCoord); break;
-                      case 28: color *= texture(u_textures[28], in_texCoord); break;
-                      case 29: color *= texture(u_textures[29], in_texCoord); break;
-                      case 30: color *= texture(u_textures[30], in_texCoord); break;
-                      case 31: color *= texture(u_textures[31], in_texCoord); break;
-                  }
-
-                  out_color = color;
-              }";
 
     /// <summary>
     ///   The input layout.
@@ -104,33 +48,6 @@ public class SpriteDrawer : ISpriteDrawer, IDisposable
     ///   The render device.
     /// </summary>
     private readonly IRenderDevice renderDevice;
-
-    /// <summary>
-    ///   The vertex shader source code.
-    /// </summary>
-    private readonly string vertexShaderSource =
-        @"#version 460
-
-              layout(location = 0) in vec2 in_position;
-              layout(location = 1) in vec4 in_color;
-              layout(location = 2) in vec2 in_texCoord;
-              layout(location = 3) in float in_textureID;
-
-              layout(location = 0) out vec4 out_color;
-              layout(location = 1) out vec2 out_texCoord;
-              layout(location = 2) out float out_textureID;
-
-              uniform mat4 u_projection;
-              uniform mat4 u_transform;
-
-              void main()
-              {
-                  out_color = in_color;
-                  out_texCoord = vec2(in_texCoord.x, 1.0 - in_texCoord.y);;
-                  out_textureID = in_textureID;
-
-                  gl_Position = u_projection * u_transform * vec4(in_position, 0.0, 1.0);
-              }";
 
     /// <summary>
     ///   The fragment shader.
@@ -184,8 +101,9 @@ public class SpriteDrawer : ISpriteDrawer, IDisposable
         this.batcher = batcher ?? throw new ArgumentNullException(nameof(batcher));
         this.binder = binder ?? throw new ArgumentNullException(nameof(binder));
 
-        this.vertexShader = renderDevice.Factory.CreateShader(PipelineTarget.Vertex, this.vertexShaderSource);
-        this.fragmentShader = renderDevice.Factory.CreateShader(PipelineTarget.Fragment, this.fragmentShaderSource);
+        this.vertexShader = ResourceManager.Instance.LoadResource<IShader>("Resources\\Shaders\\sprite-geometry.vert");
+        this.fragmentShader = ResourceManager.Instance.LoadResource<IShader>("Resources\\Shaders\\sprite-geometry.frag");
+
         this.shaderProgram = renderDevice.Factory.CreateShaderProgram(new[] { this.vertexShader, this.fragmentShader });
         this.inputLayout = renderDevice.Factory.CreateInputLayout(SpriteVertex.InputElements);
 

--- a/FinalEngine.Tests/Core/IO/FileSystemTests.cs
+++ b/FinalEngine.Tests/Core/IO/FileSystemTests.cs
@@ -21,13 +21,15 @@ public class FileSystemTests
 
     private FileSystem fileSystem;
 
+    private Mock<IPathInvoker> path;
+
     [Test]
     public void ConstructorShouldNotThrowExceptionWhenParametersArentNull()
     {
         // Arrange, act and assert
         Assert.DoesNotThrow(() =>
         {
-            new FileSystem(new Mock<IFileInvoker>().Object, new Mock<IDirectoryInvoker>().Object);
+            new FileSystem(new Mock<IFileInvoker>().Object, new Mock<IDirectoryInvoker>().Object, this.path.Object);
         });
     }
 
@@ -37,7 +39,7 @@ public class FileSystemTests
         // Arrange, act and assert
         Assert.Throws<ArgumentNullException>(() =>
         {
-            new FileSystem(new Mock<IFileInvoker>().Object, null);
+            new FileSystem(new Mock<IFileInvoker>().Object, null, this.path.Object);
         });
     }
 
@@ -47,7 +49,17 @@ public class FileSystemTests
         // Arrange, act and assert
         Assert.Throws<ArgumentNullException>(() =>
         {
-            new FileSystem(null, new Mock<IDirectoryInvoker>().Object);
+            new FileSystem(null, new Mock<IDirectoryInvoker>().Object, this.path.Object);
+        });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenPathIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new FileSystem(this.file.Object, this.directory.Object, null);
         });
     }
 
@@ -337,6 +349,36 @@ public class FileSystemTests
     }
 
     [Test]
+    public void GetExtensionShouldThrowArgumentExceptionWhenPathIsEmpty()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentException>(() =>
+        {
+            this.fileSystem.GetExtension(string.Empty);
+        });
+    }
+
+    [Test]
+    public void GetExtensionShouldThrowArgumentExceptionWhenPathIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentException>(() =>
+        {
+            this.fileSystem.GetExtension(null);
+        });
+    }
+
+    [Test]
+    public void GetExtensionShouldThrowArgumentExceptionWhenPathIsWhiteSpace()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentException>(() =>
+        {
+            this.fileSystem.GetExtension("\r\t\n");
+        });
+    }
+
+    [Test]
     public void OpenFileShouldInvokeFileOpenReadAccessWhenModeIsNotFound()
     {
         // Arrange
@@ -430,6 +472,7 @@ public class FileSystemTests
         // Arrange
         this.file = new Mock<IFileInvoker>();
         this.directory = new Mock<IDirectoryInvoker>();
-        this.fileSystem = new FileSystem(this.file.Object, this.directory.Object);
+        this.path = new Mock<IPathInvoker>();
+        this.fileSystem = new FileSystem(this.file.Object, this.directory.Object, this.path.Object);
     }
 }

--- a/FinalEngine.Tests/Extensions/Resources/Loaders/Shaders/ShaderResourceLoaderTests.cs
+++ b/FinalEngine.Tests/Extensions/Resources/Loaders/Shaders/ShaderResourceLoaderTests.cs
@@ -58,10 +58,10 @@ public sealed class ShaderResourceLoaderTests
     public void LoadResourceShouldInvokeFileSystemGetExtensionWhenFileExists()
     {
         // Act
-        this.loader.LoadResource("test.vert");
+        this.loader.LoadResource("test.vs");
 
         // Assert
-        this.fileSystem.Verify(x => x.GetExtension("test.vert"), Times.Once);
+        this.fileSystem.Verify(x => x.GetExtension("test.vs"), Times.Once);
     }
 
     [Test]
@@ -136,6 +136,8 @@ public sealed class ShaderResourceLoaderTests
 
         this.fileSystem.Setup(x => x.GetExtension("test.vert")).Returns(".vert");
         this.fileSystem.Setup(x => x.GetExtension("test.frag")).Returns(".frag");
+        this.fileSystem.Setup(x => x.GetExtension("test.vs")).Returns(".vs");
+        this.fileSystem.Setup(x => x.GetExtension("test.fs")).Returns(".fs");
         this.fileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
         this.fileSystem.Setup(x => x.OpenFile(It.IsAny<string>(), FileAccessMode.Read)).Returns(() =>
         {

--- a/FinalEngine.Tests/Extensions/Resources/Loaders/Shaders/ShaderResourceLoaderTests.cs
+++ b/FinalEngine.Tests/Extensions/Resources/Loaders/Shaders/ShaderResourceLoaderTests.cs
@@ -1,0 +1,157 @@
+// <copyright file="ShaderResourceLoaderTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Extensions.Resources.Loaders.Shaders;
+
+using System;
+using System.IO;
+using FinalEngine.Extensions.Resources.Loaders.Shaders;
+using FinalEngine.IO;
+using FinalEngine.Rendering;
+using FinalEngine.Rendering.Pipeline;
+using Moq;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class ShaderResourceLoaderTests
+{
+    private Mock<IGPUResourceFactory> factory;
+
+    private Mock<IFileSystem> fileSystem;
+
+    private ShaderResourceLoader loader;
+
+    private Mock<IShader> shader;
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenFactoryIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new ShaderResourceLoader(null, this.fileSystem.Object);
+        });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenFileSystemIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new ShaderResourceLoader(this.factory.Object, null);
+        });
+    }
+
+    [Test]
+    public void LoadResourceShouldInvokeCreateShaderWhenFileIsOpenedAndRead()
+    {
+        // Act
+        this.loader.LoadResource("test.vert");
+
+        // Assert
+        this.factory.Verify(x => x.CreateShader(PipelineTarget.Vertex, "test"), Times.Once);
+    }
+
+    [Test]
+    public void LoadResourceShouldInvokeFileSystemGetExtensionWhenFileExists()
+    {
+        // Act
+        this.loader.LoadResource("test.vert");
+
+        // Assert
+        this.fileSystem.Verify(x => x.GetExtension("test.vert"), Times.Once);
+    }
+
+    [Test]
+    public void LoadResourceShouldInvokeOpenFileWhenFileExists()
+    {
+        // Act
+        this.loader.LoadResource("test.vert");
+
+        // Assert
+        this.fileSystem.Verify(x => x.OpenFile("test.vert", FileAccessMode.Read), Times.Once);
+    }
+
+    [Test]
+    public void LoadResourceShouldThrowArgumentNullExceptionWhenFilePathIsEmpty()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            this.loader.LoadResource(string.Empty);
+        });
+    }
+
+    [Test]
+    public void LoadResourceShouldThrowArgumentNullExceptionWhenFilePathIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            this.loader.LoadResource(null);
+        });
+    }
+
+    [Test]
+    public void LoadResourceShouldThrowArgumentNullExceptionWhenFilePathIsWhitespace()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            this.loader.LoadResource("\t\n\r ");
+        });
+    }
+
+    [Test]
+    public void LoadResourceShouldThrowFileNotFoundExceptionWhenFileExistsReturnsFalse()
+    {
+        // Arrange
+        this.fileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(false);
+
+        // Act and assert
+        Assert.Throws<FileNotFoundException>(() =>
+        {
+            this.loader.LoadResource("test");
+        });
+    }
+
+    [Test]
+    public void LoadResourceShouldThrowNotSupportedExceptionWhenExtensionDoesNotExist()
+    {
+        // Act and assert
+        Assert.Throws<NotSupportedException>(() =>
+        {
+            this.loader.LoadResource("test.txt");
+        });
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.fileSystem = new Mock<IFileSystem>();
+        this.factory = new Mock<IGPUResourceFactory>();
+        this.shader = new Mock<IShader>();
+
+        this.fileSystem.Setup(x => x.GetExtension("test.vert")).Returns(".vert");
+        this.fileSystem.Setup(x => x.GetExtension("test.frag")).Returns(".frag");
+        this.fileSystem.Setup(x => x.FileExists(It.IsAny<string>())).Returns(true);
+        this.fileSystem.Setup(x => x.OpenFile(It.IsAny<string>(), FileAccessMode.Read)).Returns(() =>
+        {
+            var stream = new MemoryStream();
+            var writer = new StreamWriter(stream);
+
+            writer.Write("test");
+            writer.Flush();
+
+            stream.Position = 0;
+
+            return stream;
+        });
+
+        this.factory.Setup(x => x.CreateShader(It.IsAny<PipelineTarget>(), It.IsAny<string>())).Returns(this.shader.Object);
+
+        this.loader = new ShaderResourceLoader(this.factory.Object, this.fileSystem.Object);
+    }
+}

--- a/FinalEngine.Tests/Extensions/Resources/Loaders/Textures/Texture2DLoaderTests.cs
+++ b/FinalEngine.Tests/Extensions/Resources/Loaders/Textures/Texture2DLoaderTests.cs
@@ -2,7 +2,7 @@
 //     Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
-namespace FinalEngine.Tests.Rendering.Textures;
+namespace FinalEngine.Tests.Extensions.Resources.Loaders.Textures;
 
 using System;
 using System.IO;


### PR DESCRIPTION
# Description

- Created `ShaderResourceLoader` that loads shader resources based on their file extension.
  - `.vs` and `.vert` for vertex shaders.
  - `.fs` and `.frag` for fragment shaders.
- Updated the `SpriteDrawer` class, removing the shader source code from the class and into their own files. The sprite drawer now loads the shaders using the `ResourceManager`.
- Removed the redundant `LoadShader` function in the test application.
- Added a `GetExtension(string path)` function to the `IFileSystem`. This is used when loading shaders.

Fixes #207 

## Dependencies

There are no new dependencies that are introduced in this PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I provided unit tests for the new resource loader and updated existing unit tests. Whilst coverage is not 100%, this is something I do plan to do in the future.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ @ 2.60GHz, 16GB RAM, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Proposed Design

#### The Shader Resource Loader

```csharp
// Register the loader as normal.
ResourceManager.Instance.RegisterLoader(new ShaderResourceLoader(this.renderDevice.Factory, this.fileSystem);

// Now, just load shaders where they are required.
var shader = ResourceManager.Instance.LoadResource<IShader>("Resources\\Shaders\\shader.vert);
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
