### PR TITLE
[BUG FIX] Update AssemblyInfo for FinalEngine.Audio and FinalEngine.Audio.OpenAL projects.

### DIFF
--- a/FinalEngine.Audio.OpenAL/Properties/AssemblyInfo.cs
+++ b/FinalEngine.Audio.OpenAL/Properties/AssemblyInfo.cs
@@ -4,12 +4,10 @@
 
 using System;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
-[assembly: AssemblyTitle("FinalEngine.Resources")]
-[assembly: AssemblyDescription("A resource management library for Final Engine games.")]
-[assembly: Guid("CB2BE28E-55C1-425E-9B14-31C0BE5D5813")]
-[assembly: InternalsVisibleTo("FinalEngine.Tests")]
+[assembly: AssemblyTitle("FinalEngine.Audio.OpenAL")]
+[assembly: AssemblyDescription("An OpenAL audio library used to handle audio for Final Engine games.")]
+[assembly: Guid("13D6A388-43BA-433F-A1CC-6D2C791E8D89")]

--- a/FinalEngine.Audio/Properties/AssemblyInfo.cs
+++ b/FinalEngine.Audio/Properties/AssemblyInfo.cs
@@ -4,12 +4,10 @@
 
 using System;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 [assembly: CLSCompliant(true)]
 [assembly: ComVisible(false)]
-[assembly: AssemblyTitle("FinalEngine.Resources")]
-[assembly: AssemblyDescription("A resource management library for Final Engine games.")]
-[assembly: Guid("CB2BE28E-55C1-425E-9B14-31C0BE5D5813")]
-[assembly: InternalsVisibleTo("FinalEngine.Tests")]
+[assembly: AssemblyTitle("FinalEngine.Audio")]
+[assembly: AssemblyDescription("A core audio library used to handle audio for Final Engine games.")]
+[assembly: Guid("EEF6B5AF-A4A9-47CF-8C1A-A0068E4B4F9D")]


### PR DESCRIPTION
# Description

- Updated `Guid` for both projects.
- Updated descriptions for both projects.
- Removed `InternalsVisibleTo` attribute for both projects as it's not required.

Fixes #194 

## Dependencies

There are no new dependencies introduced in this PR.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## How Has This Been Tested?

I tested my changed by building and running the entire solution.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ @ 2.60GHz, 16GB RAM, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
