### PR TITLE
[CLEANUP] FIxup invocation classes by adding better constructor.

### DIFF
--- a/FinalEngine.Examples.Game/Program.cs
+++ b/FinalEngine.Examples.Game/Program.cs
@@ -8,7 +8,6 @@ using System;
 using System.Diagnostics;
 using System.Drawing;
 using System.Numerics;
-using FinalEngine.Extensions.Resources.Invocation;
 using FinalEngine.Extensions.Resources.Loaders.Audio;
 using FinalEngine.Extensions.Resources.Loaders.Shaders;
 using FinalEngine.Extensions.Resources.Loaders.Textures;
@@ -86,7 +85,7 @@ internal static class Program
 
         resourceManager.RegisterLoader(new SoundResourceLoader(fileSystem));
         resourceManager.RegisterLoader(new ShaderResourceLoader(renderDevice.Factory, fileSystem));
-        resourceManager.RegisterLoader(new Texture2DResourceLoader(fileSystem, renderDevice.Factory, new ImageInvoker()));
+        resourceManager.RegisterLoader(new Texture2DResourceLoader(fileSystem, renderDevice.Factory));
 
         displayManager.ChangeResolution(DisplayResolution.HighDefinition);
 

--- a/FinalEngine.Examples.Game/Program.cs
+++ b/FinalEngine.Examples.Game/Program.cs
@@ -5,7 +5,6 @@
 namespace FinalEngine.Examples.Game;
 
 using System;
-using System.Diagnostics;
 using System.Drawing;
 using System.Numerics;
 using FinalEngine.Extensions.Resources.Loaders.Audio;
@@ -14,17 +13,14 @@ using FinalEngine.Extensions.Resources.Loaders.Textures;
 using FinalEngine.Input.Keyboards;
 using FinalEngine.Input.Mouses;
 using FinalEngine.IO;
-using FinalEngine.IO.Invocation;
 using FinalEngine.Maths;
 using FinalEngine.Platform.Desktop.OpenTK;
 using FinalEngine.Platform.Desktop.OpenTK.Invocation;
 using FinalEngine.Rendering;
 using FinalEngine.Rendering.OpenGL;
-using FinalEngine.Rendering.OpenGL.Invocation;
 using FinalEngine.Rendering.Pipeline;
 using FinalEngine.Resources;
 using FinalEngine.Runtime;
-using FinalEngine.Runtime.Invocation;
 using FinalEngine.Runtime.Rendering;
 using OpenTK.Windowing.Common;
 using OpenTK.Windowing.Desktop;
@@ -59,10 +55,7 @@ internal static class Program
         var nativeWindow = new NativeWindowInvoker(settings);
         var window = new OpenTKWindow(nativeWindow);
 
-        var file = new FileInvoker();
-        var directory = new DirectoryInvoker();
-        var path = new PathInvoker();
-        var fileSystem = new FileSystem(file, directory, path);
+        var fileSystem = new FileSystem();
 
         var keyboardDevice = new OpenTKKeyboardDevice(nativeWindow);
         var keyboard = new Keyboard(keyboardDevice);
@@ -70,18 +63,14 @@ internal static class Program
         var mouseDevice = new OpenTKMouseDevice(nativeWindow);
         var mouse = new Mouse(mouseDevice);
 
-        var opengl = new OpenGLInvoker();
         var bindings = new GLFWBindingsContext();
-
-        var renderContext = new OpenGLRenderContext(opengl, bindings, nativeWindow.Context);
-        var renderDevice = new OpenGLRenderDevice(opengl);
+        var renderContext = new OpenGLRenderContext(bindings, nativeWindow.Context);
+        var renderDevice = new OpenGLRenderDevice();
 
         var displayManager = new DisplayManager(renderDevice.Rasterizer, window);
         var resourceManager = ResourceManager.Instance;
 
-        var watch = new Stopwatch();
-        var watchInvoker = new StopwatchInvoker(watch);
-        var gameTime = new GameTime(watchInvoker, 120.0d);
+        var gameTime = new GameTime(120.0d);
 
         resourceManager.RegisterLoader(new SoundResourceLoader(fileSystem));
         resourceManager.RegisterLoader(new ShaderResourceLoader(renderDevice.Factory, fileSystem));

--- a/FinalEngine.Extensions.Resources/Loaders/Textures/Texture2DResourceLoader.cs
+++ b/FinalEngine.Extensions.Resources/Loaders/Textures/Texture2DResourceLoader.cs
@@ -37,6 +37,20 @@ public class Texture2DResourceLoader : ResourceLoaderBase<ITexture2D>
     private readonly IImageInvoker invoker;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="Texture2DResourceLoader"/> class.
+    /// </summary>
+    /// <param name="fileSystem">
+    ///   The file system used to open textures to load.
+    /// </param>
+    /// <param name="factory">
+    ///   The GPU resource factory used to create a texture once it's been loaded.
+    /// </param>
+    public Texture2DResourceLoader(IFileSystem fileSystem, IGPUResourceFactory factory)
+        : this(fileSystem, factory, new ImageInvoker())
+    {
+    }
+
+    /// <summary>
     ///   Initializes a new instance of the <see cref="Texture2DResourceLoader"/> class.
     /// </summary>
     /// <param name="fileSystem">

--- a/FinalEngine.IO/FileSystem.cs
+++ b/FinalEngine.IO/FileSystem.cs
@@ -37,6 +37,14 @@ public class FileSystem : IFileSystem
     /// <summary>
     /// Initializes a new instance of the <see cref="FileSystem"/> class.
     /// </summary>
+    public FileSystem()
+        : this(new FileInvoker(), new DirectoryInvoker(), new PathInvoker())
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileSystem"/> class.
+    /// </summary>
     /// <param name="file">
     /// Specifies an <see cref="IFileInvoker"/> that represents the invoker used to handle file operations.
     /// </param>

--- a/FinalEngine.Rendering.OpenGL/OpenGLRenderContext.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLRenderContext.cs
@@ -37,6 +37,20 @@ public class OpenGLRenderContext : IRenderContext
     /// <summary>
     ///   Initializes a new instance of the <see cref="OpenGLRenderContext"/> class.
     /// </summary>
+    /// <param name="bindings">
+    ///   Specifies an <see cref="IBindingsContext"/> that represents the bindings context used to load the OpenGL bindings.
+    /// </param>
+    /// <param name="context">
+    ///   Specifies an <see cref="IGraphicsContext"/> that represents the underlying rendering context.
+    /// </param>
+    public OpenGLRenderContext(IBindingsContext bindings, IGraphicsContext context)
+        : this(new OpenGLInvoker(), bindings, context)
+    {
+    }
+
+    /// <summary>
+    ///   Initializes a new instance of the <see cref="OpenGLRenderContext"/> class.
+    /// </summary>
     /// <param name="invoker">
     ///   Specifies an <see cref="IOpenGLInvoker"/> that represents the invoker used to invoke OpenGL calls.
     /// </param>

--- a/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
+++ b/FinalEngine.Rendering.OpenGL/OpenGLRenderDevice.cs
@@ -41,6 +41,14 @@ public class OpenGLRenderDevice : IRenderDevice
     private readonly IEnumMapper mapper;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="OpenGLRenderDevice"/> class.
+    /// </summary>
+    public OpenGLRenderDevice()
+        : this(new OpenGLInvoker())
+    {
+    }
+
+    /// <summary>
     ///   Initializes a new instance of the <see cref="OpenGLRenderDevice"/> class.
     /// </summary>
     /// <param name="invoker">

--- a/FinalEngine.Runtime/GameTime.cs
+++ b/FinalEngine.Runtime/GameTime.cs
@@ -5,7 +5,6 @@
 namespace FinalEngine.Runtime;
 
 using System;
-using System.Diagnostics;
 using FinalEngine.Runtime.Invocation;
 
 /// <summary>
@@ -41,7 +40,7 @@ public class GameTime : IGameTime
     /// The frame cap.
     /// </param>
     public GameTime(double frameCap)
-        : this(new StopwatchInvoker(new Stopwatch()), frameCap)
+        : this(new StopwatchInvoker(), frameCap)
     {
     }
 

--- a/FinalEngine.Runtime/Invocation/StopwatchInvoker.cs
+++ b/FinalEngine.Runtime/Invocation/StopwatchInvoker.cs
@@ -21,6 +21,14 @@ public class StopwatchInvoker : IStopwatchInvoker
     private readonly Stopwatch watch;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="StopwatchInvoker"/> class.
+    /// </summary>
+    public StopwatchInvoker()
+        : this(new Stopwatch())
+    {
+    }
+
+    /// <summary>
     ///   Initializes a new instance of the <see cref="StopwatchInvoker"/> class.
     /// </summary>
     /// <param name="watch">


### PR DESCRIPTION
# Description

- Added new constructor to `FileSystem` to create invocation classes directly.
- Added new constructor to `OpenGLRenderContext` to create invocation class directly.
- Added new constructor to `OpenGLRenderDevice` to create invocation class directly.
- Added new constructor to `StopwatchInvoker` to create `Stopwatch` directly.
- Added new constructor to `GameTime` to create `IStopWatchInvoker` implementation directly.

Fixes #216 

## Dependencies

This PR introduces no new dependencies.

## Type of change

- [x] Other: General Cleanup
## How Has This Been Tested?

I tested my changed by building and running the entire solution.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ @ 2.60GHz, 16GB RAM, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings