### PR TITLE
[FEATURE] Create WPF Main Window

### DIFF
--- a/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
+++ b/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
@@ -1,0 +1,31 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>11.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AnalysisMode>All</AnalysisMode>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/FinalEngine.Editor.Common/Properties/AssemblyInfo.cs
+++ b/FinalEngine.Editor.Common/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+// <copyright file="AssemblyInfo.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+[assembly: AssemblyTitle("FinalEngine.Editor.Common")]
+[assembly: AssemblyDescription("A common library containing services to connect view models to view for the Final Engine editor.")]
+[assembly: Guid("3D606010-8CAF-4781-98D1-EB67BCDD8CC1")]

--- a/FinalEngine.Editor.Common/Services/Application/ApplicationContext.cs
+++ b/FinalEngine.Editor.Common/Services/Application/ApplicationContext.cs
@@ -7,15 +7,21 @@ namespace FinalEngine.Editor.Common.Services.Application;
 using System;
 using System.Reflection;
 
+/// <summary>
+/// Provides a standard implementation of an <see cref="IApplicationContext"/>.
+/// </summary>
+/// <seealso cref="IApplicationContext" />
 public sealed class ApplicationContext : IApplicationContext
 {
+    /// <inheritdoc/>
     public string Title
     {
         get { return $"Final Engine - {this.Version}"; }
     }
 
+    /// <inheritdoc/>
     public Version Version
     {
-        get { return Assembly.GetExecutingAssembly().GetName().Version ?? new Version(DateTime.UtcNow.Year, 0); }
+        get { return Assembly.GetExecutingAssembly().GetName().Version!; }
     }
 }

--- a/FinalEngine.Editor.Common/Services/Application/ApplicationContext.cs
+++ b/FinalEngine.Editor.Common/Services/Application/ApplicationContext.cs
@@ -1,0 +1,21 @@
+// <copyright file="ApplicationContext.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Application;
+
+using System;
+using System.Reflection;
+
+public sealed class ApplicationContext : IApplicationContext
+{
+    public string Title
+    {
+        get { return $"Final Engine - {this.Version}"; }
+    }
+
+    public Version Version
+    {
+        get { return Assembly.GetExecutingAssembly().GetName().Version ?? new Version(DateTime.UtcNow.Year, 0); }
+    }
+}

--- a/FinalEngine.Editor.Common/Services/Application/IApplicationContext.cs
+++ b/FinalEngine.Editor.Common/Services/Application/IApplicationContext.cs
@@ -1,0 +1,14 @@
+// <copyright file="IApplicationContext.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Application;
+
+using System;
+
+public interface IApplicationContext
+{
+    string Title { get; }
+
+    Version Version { get; }
+}

--- a/FinalEngine.Editor.Common/Services/Application/IApplicationContext.cs
+++ b/FinalEngine.Editor.Common/Services/Application/IApplicationContext.cs
@@ -6,9 +6,24 @@ namespace FinalEngine.Editor.Common.Services.Application;
 
 using System;
 
+/// <summary>
+/// Defines an interface that represents contextual information related to the current application.
+/// </summary>
 public interface IApplicationContext
 {
+    /// <summary>
+    /// Gets the title of the application.
+    /// </summary>
+    /// <value>
+    /// The title of the application.
+    /// </value>
     string Title { get; }
 
+    /// <summary>
+    /// Gets the version of the application.
+    /// </summary>
+    /// <value>
+    /// The version of the application.
+    /// </value>
     Version Version { get; }
 }

--- a/FinalEngine.Editor.Desktop/App.xaml
+++ b/FinalEngine.Editor.Desktop/App.xaml
@@ -1,0 +1,14 @@
+<Application x:Class="FinalEngine.Editor.Desktop.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Themes/Dark.Blue.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Colors.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/VS/Controls.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -18,6 +18,9 @@ using Microsoft.Extensions.Logging;
 /// </summary>
 public partial class App : Application
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="App"/> class.
+    /// </summary>
     public App()
     {
         AppHost = Host.CreateDefaultBuilder()
@@ -25,14 +28,32 @@ public partial class App : Application
             .Build();
     }
 
+    /// <summary>
+    /// Gets or sets the application host.
+    /// </summary>
+    /// <value>
+    /// The application host.
+    /// </value>
     private static IHost? AppHost { get; set; }
 
+    /// <summary>
+    /// Exits the main application, disposing of any existing resources.
+    /// </summary>
+    /// <param name="e">
+    /// The <see cref="ExitEventArgs"/> instance containing the event data.
+    /// </param>
     protected override async void OnExit(ExitEventArgs e)
     {
         await AppHost!.StopAsync().ConfigureAwait(false);
         base.OnExit(e);
     }
 
+    /// <summary>
+    /// Starts up the main application on the current platform.
+    /// </summary>
+    /// <param name="e">
+    ///   A <see cref="StartupEventArgs"/> that contains the event data.
+    /// </param>
     protected override async void OnStartup(StartupEventArgs e)
     {
         await AppHost!.StartAsync().ConfigureAwait(false);
@@ -49,6 +70,15 @@ public partial class App : Application
         base.OnStartup(e);
     }
 
+    /// <summary>
+    /// Configures the services to be consumed by the application.
+    /// </summary>
+    /// <param name="context">
+    /// The application host builder context.
+    /// </param>
+    /// <param name="services">
+    /// The services to be consumed by the application.
+    /// </param>
     private static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
     {
         services.AddLogging(builder =>

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -1,0 +1,62 @@
+// <copyright file="App.xaml.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Desktop;
+
+using System.Diagnostics;
+using System.Windows;
+using FinalEngine.Editor.Common.Services.Application;
+using FinalEngine.Editor.Desktop.Views;
+using FinalEngine.Editor.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Interaction logic for App.xaml.
+/// </summary>
+public partial class App : Application
+{
+    public App()
+    {
+        AppHost = Host.CreateDefaultBuilder()
+            .ConfigureServices(ConfigureServices)
+            .Build();
+    }
+
+    private static IHost? AppHost { get; set; }
+
+    protected override async void OnExit(ExitEventArgs e)
+    {
+        await AppHost!.StopAsync().ConfigureAwait(false);
+        base.OnExit(e);
+    }
+
+    protected override async void OnStartup(StartupEventArgs e)
+    {
+        await AppHost!.StartAsync().ConfigureAwait(false);
+
+        var viewModel = AppHost.Services.GetRequiredService<IMainViewModel>();
+
+        var view = new MainView()
+        {
+            DataContext = viewModel,
+        };
+
+        view.ShowDialog();
+
+        base.OnStartup(e);
+    }
+
+    private static void ConfigureServices(HostBuilderContext context, IServiceCollection services)
+    {
+        services.AddLogging(builder =>
+        {
+            builder.AddConsole().SetMinimumLevel(Debugger.IsAttached ? LogLevel.Debug : LogLevel.Information);
+        });
+
+        services.AddSingleton<IApplicationContext, ApplicationContext>();
+        services.AddTransient<IMainViewModel, MainViewModel>();
+    }
+}

--- a/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
+++ b/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <UseWPF>true</UseWPF>
+    <LangVersion>11.0</LangVersion>
+    <AnalysisMode>All</AnalysisMode>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MahApps.Metro" Version="2.4.10" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj" />
+  </ItemGroup>
+</Project>

--- a/FinalEngine.Editor.Desktop/Properties/AssemblyInfo.cs
+++ b/FinalEngine.Editor.Desktop/Properties/AssemblyInfo.cs
@@ -1,0 +1,15 @@
+// <copyright file="AssemblyInfo.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Windows;
+
+[assembly: CLSCompliant(false)]
+[assembly: ComVisible(false)]
+[assembly: AssemblyTitle("FinalEngine.Editor.Desktop")]
+[assembly: AssemblyDescription("The main editor application for Final Engine")]
+[assembly: Guid("18F55601-F1DE-4260-88A8-2F54CA08CA93")]
+[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]

--- a/FinalEngine.Editor.Desktop/Views/MainView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/MainView.xaml
@@ -1,0 +1,39 @@
+<mah:MetroWindow x:Name="Window"
+                 x:Class="FinalEngine.Editor.Desktop.Views.MainView"
+                 xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                 xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 mc:Ignorable="d"
+                 Width="1280"
+                 Height="720"
+                 GlowBrush="{DynamicResource MahApps.Brushes.Accent2}"
+                 NonActiveGlowBrush="{DynamicResource MahApps.Brushes.Accent4}"
+                 BorderThickness="2"
+                 WindowStartupLocation="CenterScreen"
+                 WindowState="Maximized"
+                 Title="{Binding Title}"
+                 TitleAlignment="Right">
+
+    <!-- KEY BINDINGS -->
+    <Window.InputBindings>
+        <KeyBinding Gesture="Alt+F4" Command="{Binding ExitCommand}" CommandParameter="{Binding ElementName=Window}" />
+    </Window.InputBindings>
+
+    <!-- MAIN MENU -->
+    <mah:MetroWindow.LeftWindowCommands>
+        <mah:WindowCommands ShowLastSeparator="False">
+            <Menu IsMainMenu="True">
+
+                <!-- FILE -->
+                <MenuItem Header="_File">
+                    <MenuItem Header="E_xit" InputGestureText="Alt+F4" Command="{Binding ExitCommand}" CommandParameter="{Binding ElementName=Window}" />
+                </MenuItem>
+            </Menu>
+        </mah:WindowCommands>
+    </mah:MetroWindow.LeftWindowCommands>
+
+    <Grid>
+    </Grid>
+</mah:MetroWindow>

--- a/FinalEngine.Editor.Desktop/Views/MainView.xaml.cs
+++ b/FinalEngine.Editor.Desktop/Views/MainView.xaml.cs
@@ -1,0 +1,22 @@
+// <copyright file="MainView.xaml.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Desktop.Views;
+
+using FinalEngine.Editor.ViewModels.Interactions;
+using MahApps.Metro.Controls;
+
+/// <summary>
+/// Interaction logic for MainView.xaml.
+/// </summary>
+public partial class MainView : MetroWindow, ICloseable
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainView"/> class.
+    /// </summary>
+    public MainView()
+    {
+        this.InitializeComponent();
+    }
+}

--- a/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
+++ b/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <LangVersion>11.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <AnalysisMode>All</AnalysisMode>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Platforms>x64</Platforms>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\Styling\StyleCop\Other\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\SharedAssemblyInfo.cs" Link="Properties\SharedAssemblyInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.Editor.Common\FinalEngine.Editor.Common.csproj" />
+  </ItemGroup>
+</Project>

--- a/FinalEngine.Editor.ViewModels/GlobalSuppressions.cs
+++ b/FinalEngine.Editor.ViewModels/GlobalSuppressions.cs
@@ -1,7 +1,6 @@
-// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
+// <copyright file="GlobalSuppressions.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/FinalEngine.Editor.ViewModels/GlobalSuppressions.cs
+++ b/FinalEngine.Editor.ViewModels/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates", Justification = "KISS")]

--- a/FinalEngine.Editor.ViewModels/IMainViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/IMainViewModel.cs
@@ -6,9 +6,24 @@ namespace FinalEngine.Editor.ViewModels;
 
 using System.Windows.Input;
 
+/// <summary>
+/// Defines an interface that represents a model of the main view.
+/// </summary>
 public interface IMainViewModel
 {
+    /// <summary>
+    /// Gets the exit command.
+    /// </summary>
+    /// <value>
+    /// The exit command.
+    /// </value>
     ICommand ExitCommand { get; }
 
+    /// <summary>
+    /// Gets the title.
+    /// </summary>
+    /// <value>
+    /// The title.
+    /// </value>
     string Title { get; }
 }

--- a/FinalEngine.Editor.ViewModels/IMainViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/IMainViewModel.cs
@@ -1,0 +1,14 @@
+// <copyright file="IMainViewModel.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels;
+
+using System.Windows.Input;
+
+public interface IMainViewModel
+{
+    ICommand ExitCommand { get; }
+
+    string Title { get; }
+}

--- a/FinalEngine.Editor.ViewModels/Interactions/ICloseable.cs
+++ b/FinalEngine.Editor.ViewModels/Interactions/ICloseable.cs
@@ -1,0 +1,10 @@
+// <copyright file="ICloseable.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Interactions;
+
+public interface ICloseable
+{
+    void Close();
+}

--- a/FinalEngine.Editor.ViewModels/Interactions/ICloseable.cs
+++ b/FinalEngine.Editor.ViewModels/Interactions/ICloseable.cs
@@ -4,7 +4,13 @@
 
 namespace FinalEngine.Editor.ViewModels.Interactions;
 
+/// <summary>
+/// Defines an interface that represents an interaction to close a view.
+/// </summary>
 public interface ICloseable
 {
+    /// <summary>
+    /// Closes the view.
+    /// </summary>
     void Close();
 }

--- a/FinalEngine.Editor.ViewModels/MainViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/MainViewModel.cs
@@ -12,14 +12,40 @@ using FinalEngine.Editor.Common.Services.Application;
 using FinalEngine.Editor.ViewModels.Interactions;
 using Microsoft.Extensions.Logging;
 
+/// <summary>
+/// Provides a standard implementation of an <see cref="IMainViewModel"/>.
+/// </summary>
+/// <seealso cref="ObservableObject" />
+/// <seealso cref="IMainViewModel" />
 public sealed class MainViewModel : ObservableObject, IMainViewModel
 {
+    /// <summary>
+    /// The logger.
+    /// </summary>
     private readonly ILogger<MainViewModel> logger;
 
+    /// <summary>
+    /// The exit command.
+    /// </summary>
     private ICommand? exitCommand;
 
+    /// <summary>
+    /// The title of the application.
+    /// </summary>
     private string? title;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MainViewModel"/> class.
+    /// </summary>
+    /// <param name="logger">
+    /// The logger.
+    /// </param>
+    /// <param name="context">
+    /// The application context.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="logger"/> or <paramref name="context"/> parameter cannot be null.
+    /// </exception>
     public MainViewModel(
         ILogger<MainViewModel> logger,
         IApplicationContext context)
@@ -34,17 +60,38 @@ public sealed class MainViewModel : ObservableObject, IMainViewModel
         this.Title = context.Title;
     }
 
+    /// <summary>
+    /// Gets the exit command.
+    /// </summary>
+    /// <value>
+    /// The exit command.
+    /// </value>
     public ICommand ExitCommand
     {
         get { return this.exitCommand ??= new RelayCommand<ICloseable>(this.Close); }
     }
 
+    /// <summary>
+    /// Gets the title of the application.
+    /// </summary>
+    /// <value>
+    /// The title of the application.
+    /// </value>
     public string Title
     {
         get { return this.title ?? string.Empty; }
         private set { this.SetProperty(ref this.title, value); }
     }
 
+    /// <summary>
+    /// Closes the main view using the specified <paramref name="closeable"/> interaction.
+    /// </summary>
+    /// <param name="closeable">
+    /// The closeable interaction used to close the main view.
+    /// .</param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="closeable"/> parameter cannot be null.
+    /// </exception>
     private void Close(ICloseable? closeable)
     {
         if (closeable == null)

--- a/FinalEngine.Editor.ViewModels/MainViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/MainViewModel.cs
@@ -1,0 +1,59 @@
+// <copyright file="MainViewModel.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels;
+
+using System;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using FinalEngine.Editor.Common.Services.Application;
+using FinalEngine.Editor.ViewModels.Interactions;
+using Microsoft.Extensions.Logging;
+
+public sealed class MainViewModel : ObservableObject, IMainViewModel
+{
+    private readonly ILogger<MainViewModel> logger;
+
+    private ICommand? exitCommand;
+
+    private string? title;
+
+    public MainViewModel(
+        ILogger<MainViewModel> logger,
+        IApplicationContext context)
+    {
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        this.Title = context.Title;
+    }
+
+    public ICommand ExitCommand
+    {
+        get { return this.exitCommand ??= new RelayCommand<ICloseable>(this.Close); }
+    }
+
+    public string Title
+    {
+        get { return this.title ?? string.Empty; }
+        private set { this.SetProperty(ref this.title, value); }
+    }
+
+    private void Close(ICloseable? closeable)
+    {
+        if (closeable == null)
+        {
+            throw new ArgumentNullException(nameof(closeable));
+        }
+
+        this.logger.LogDebug($"Closing {nameof(MainViewModel)}...");
+
+        closeable.Close();
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Properties/AssemblyInfo.cs
+++ b/FinalEngine.Editor.ViewModels/Properties/AssemblyInfo.cs
@@ -1,0 +1,13 @@
+// <copyright file="AssemblyInfo.cs" company="Software Antics">
+//     Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+[assembly: CLSCompliant(true)]
+[assembly: ComVisible(false)]
+[assembly: AssemblyTitle("FinalEngine.Editor.ViewModels")]
+[assembly: AssemblyDescription("A library containing view models for the Final Engine editor.")]
+[assembly: Guid("BDA4CEFA-DD44-4FD7-AE54-330C571809C9")]

--- a/FinalEngine.Editor.ViewModels/Properties/AssemblyInfo.cs
+++ b/FinalEngine.Editor.ViewModels/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: CLSCompliant(true)]
+[assembly: CLSCompliant(false)]
 [assembly: ComVisible(false)]
 [assembly: AssemblyTitle("FinalEngine.Editor.ViewModels")]
 [assembly: AssemblyDescription("A library containing view models for the Final Engine editor.")]

--- a/FinalEngine.Tests/Editor/Common/Services/Application/ApplicationContextTests.cs
+++ b/FinalEngine.Tests/Editor/Common/Services/Application/ApplicationContextTests.cs
@@ -1,0 +1,57 @@
+// <copyright file="ApplicationContextTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.Common.Services.Application;
+
+using System.Reflection;
+using FinalEngine.Editor.Common.Services.Application;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class ApplicationContextTests
+{
+    private ApplicationContext context;
+
+    [Test]
+    public void ConstructorShouldNotThrowExceptionWhenInvoked()
+    {
+        // Act and assert
+        Assert.DoesNotThrow(() =>
+        {
+            new ApplicationContext();
+        });
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.context = new ApplicationContext();
+    }
+
+    [Test]
+    public void TitleShouldReturnFinalEngineAndVersionWhenInvoked()
+    {
+        // Arrange
+        string expected = $"Final Engine - {Assembly.GetExecutingAssembly().GetName().Version}";
+
+        // Act
+        string actual = this.context.Title;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void VersionShouldReturnAssemblyVersionWhenInvoked()
+    {
+        // Arrange
+        var expected = Assembly.GetExecutingAssembly().GetName().Version;
+
+        // Act
+        var actual = this.context.Version;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/MainViewModelTests.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/MainViewModelTests.cs
@@ -1,0 +1,120 @@
+// <copyright file="MainViewModelTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels;
+
+using System;
+using CommunityToolkit.Mvvm.Input;
+using FinalEngine.Editor.Common.Services.Application;
+using FinalEngine.Editor.ViewModels;
+using FinalEngine.Editor.ViewModels.Interactions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class MainViewModelTests
+{
+    private Mock<IApplicationContext> context;
+
+    private Mock<ILogger<MainViewModel>> logger;
+
+    private MainViewModel viewModel;
+
+    [Test]
+    public void ConstructorShouldSetTitleToApplicationContextTitleWhenInvoked()
+    {
+        // Arrange
+        const string expected = "Final Engine";
+
+        // Act
+        string actual = this.viewModel.Title;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ConstructorShouldSetTitleToStringEmptyWhenApplicationContextTitleIsNull()
+    {
+        // Arrange
+        string expected = string.Empty;
+        this.context.Setup(x => x.Title).Returns(() =>
+        {
+            return null;
+        });
+
+        var viewModel = new MainViewModel(this.logger.Object, this.context.Object);
+
+        // Act
+        string actual = viewModel.Title;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenContextIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new MainViewModel(this.logger.Object, null);
+        });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenLoggerIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new MainViewModel(null, this.context.Object);
+        });
+    }
+
+    [Test]
+    public void ExitCommandExecuteShouldInvokeCloseableCloseWhenInvoked()
+    {
+        // Arrange
+        var closeable = new Mock<ICloseable>();
+
+        // Act
+        this.viewModel.ExitCommand.Execute(closeable.Object);
+
+        // Assert
+        closeable.Verify(x => x.Close(), Times.Once);
+    }
+
+    [Test]
+    public void ExitCommandExecuteShouldThrowArgumentNullExceptionWhenCloseableIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            this.viewModel.ExitCommand.Execute(null);
+        });
+    }
+
+    [Test]
+    public void ExitCommandShouldReturnNewRelayCommandWhenInvoked()
+    {
+        // Act
+        var command = this.viewModel.ExitCommand;
+
+        // Assert
+        Assert.That(command, Is.InstanceOf<RelayCommand<ICloseable>>());
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.logger = new Mock<ILogger<MainViewModel>>();
+
+        this.context = new Mock<IApplicationContext>();
+        this.context.Setup(x => x.Title).Returns("Final Engine");
+
+        this.viewModel = new MainViewModel(this.logger.Object, this.context.Object);
+    }
+}

--- a/FinalEngine.Tests/FinalEngine.Tests.csproj
+++ b/FinalEngine.Tests/FinalEngine.Tests.csproj
@@ -40,6 +40,8 @@
 
 	<ItemGroup>
 		<ProjectReference Include="..\FinalEngine.ECS\FinalEngine.ECS.csproj" />
+		<ProjectReference Include="..\FinalEngine.Editor.Common\FinalEngine.Editor.Common.csproj" />
+		<ProjectReference Include="..\FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj" />
 		<ProjectReference Include="..\FinalEngine.Extensions.Resources\FinalEngine.Extensions.Resources.csproj" />
 		<ProjectReference Include="..\FinalEngine.Input\FinalEngine.Input.csproj" />
 		<ProjectReference Include="..\FinalEngine.IO\FinalEngine.IO.csproj" />

--- a/FinalEngine.sln
+++ b/FinalEngine.sln
@@ -62,7 +62,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Audio.OpenAL", 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Examples", "Examples", "{C3EB22AD-1D4F-4270-B5D6-ABAFCC0558ED}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Examples.Game", "FinalEngine.Examples.Game\FinalEngine.Examples.Game.csproj", "{5B492FC2-A4FD-4C2D-AD17-3F9699E5D112}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FinalEngine.Examples.Game", "FinalEngine.Examples.Game\FinalEngine.Examples.Game.csproj", "{5B492FC2-A4FD-4C2D-AD17-3F9699E5D112}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Editor", "Editor", "{A000B9CF-02DF-4BC6-9F88-36D723041F73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Editor.Common", "FinalEngine.Editor.Common\FinalEngine.Editor.Common.csproj", "{AF7D33F8-7581-4B2C-83A1-B78370C0C094}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Editor.ViewModels", "FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj", "{F3F731DE-A676-40E5-9308-4FBA387483E8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinalEngine.Editor.Desktop", "FinalEngine.Editor.Desktop\FinalEngine.Editor.Desktop.csproj", "{4CFA5490-082F-46F5-9CBB-3A3318FCE5FC}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -142,6 +150,18 @@ Global
 		{5B492FC2-A4FD-4C2D-AD17-3F9699E5D112}.Debug|x64.Build.0 = Debug|x64
 		{5B492FC2-A4FD-4C2D-AD17-3F9699E5D112}.Release|x64.ActiveCfg = Release|Any CPU
 		{5B492FC2-A4FD-4C2D-AD17-3F9699E5D112}.Release|x64.Build.0 = Release|Any CPU
+		{AF7D33F8-7581-4B2C-83A1-B78370C0C094}.Debug|x64.ActiveCfg = Debug|x64
+		{AF7D33F8-7581-4B2C-83A1-B78370C0C094}.Debug|x64.Build.0 = Debug|x64
+		{AF7D33F8-7581-4B2C-83A1-B78370C0C094}.Release|x64.ActiveCfg = Release|Any CPU
+		{AF7D33F8-7581-4B2C-83A1-B78370C0C094}.Release|x64.Build.0 = Release|Any CPU
+		{F3F731DE-A676-40E5-9308-4FBA387483E8}.Debug|x64.ActiveCfg = Debug|x64
+		{F3F731DE-A676-40E5-9308-4FBA387483E8}.Debug|x64.Build.0 = Debug|x64
+		{F3F731DE-A676-40E5-9308-4FBA387483E8}.Release|x64.ActiveCfg = Release|Any CPU
+		{F3F731DE-A676-40E5-9308-4FBA387483E8}.Release|x64.Build.0 = Release|Any CPU
+		{4CFA5490-082F-46F5-9CBB-3A3318FCE5FC}.Debug|x64.ActiveCfg = Debug|x64
+		{4CFA5490-082F-46F5-9CBB-3A3318FCE5FC}.Debug|x64.Build.0 = Debug|x64
+		{4CFA5490-082F-46F5-9CBB-3A3318FCE5FC}.Release|x64.ActiveCfg = Release|Any CPU
+		{4CFA5490-082F-46F5-9CBB-3A3318FCE5FC}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -165,6 +185,9 @@ Global
 		{E153C9B7-F8A5-43B6-B112-84739E7E9224} = {B4084D99-8DC5-4E1C-B5BF-9C7351CE71B8}
 		{D67794A8-89AC-46E0-B303-94110BB382F8} = {B4084D99-8DC5-4E1C-B5BF-9C7351CE71B8}
 		{5B492FC2-A4FD-4C2D-AD17-3F9699E5D112} = {C3EB22AD-1D4F-4270-B5D6-ABAFCC0558ED}
+		{AF7D33F8-7581-4B2C-83A1-B78370C0C094} = {A000B9CF-02DF-4BC6-9F88-36D723041F73}
+		{F3F731DE-A676-40E5-9308-4FBA387483E8} = {A000B9CF-02DF-4BC6-9F88-36D723041F73}
+		{4CFA5490-082F-46F5-9CBB-3A3318FCE5FC} = {A000B9CF-02DF-4BC6-9F88-36D723041F73}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A278B383-0D14-41B3-A71C-4505E1D503DF}


### PR DESCRIPTION
# Description

- Fulfilled requirements of #222. 
- Created three new projects:
  - `FinalEngine.Editor.Common` - Contains services that connect views and view models.
  - `FinalEngine.Editor.Desktop` - Contains the views for the editor, this is the main WPF application.
  - `FinalEngine.Editor.ViewModels` - Contains view models and interaction interfaces to make it easier to manipulate views.
- Created `MainView` and met the requirements of #222 by styling and adding a _File > Exit_ `MenuItem` and `KeyBinding`.
- Created `MainViewModel` and corresponding interface to handle updating the `MainView` title and `ExitCommand`.

## Dependencies

- `FinalEngine.Editor.Desktop`
  - [MahApps.Metro 2.4.10](https://www.nuget.org/packages/MahApps.Metro).
  - [Microsoft.Extensions.Hosting 7.0.1](https://www.nuget.org/packages/Microsoft.Extensions.Hosting/).
  - [Microsoft.Extensions.Hosting.Abstractions 7.0.0](https://www.nuget.org/packages/Microsoft.Extensions.Hosting.Abstractions/).
- `FinalEngine.Editor.ViewModels`
  - [CommunityToolkit.Mvvm 8.2.1](https://www.nuget.org/packages/CommunityToolkit.Mvvm).
  - [Microsoft.Extensions.Logging.Abstractions 7.0.0](https://www.nuget.org/packages/Microsoft.Extensions.Logging.Abstractions/).

## Type of change

- [x] Epic: #112 
- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

Unit tests have been provided for all testable changes. All unit tests are passing locally on my machine. I also ran the application and was able to manually test the `ExitCommand` to ensure the application closed both by clicking the button and using the _Alt+F4_ `KeyBinding`.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ @ 2.60GHz, 16GB, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Proposed Design

#### Interactions

The PR introduces a new concept to the editor called interactions. Interactions are simple interfaces that provide functionality to the view model from the view. For example, an `ICloseable` interface can be passed from the view to the view model via a command parameter in order to close the corresponding view once an operation is complete:

```csharp
public void Close(ICloseable? closeable)
{
    if (!this.ShouldClose)
    {
        return;
    }

    closeable?.Close();
}
```

## Screenshots

![image](https://github.com/softwareantics/FinalEngine/assets/50978201/09089e75-4cb4-4951-8e21-321ec48ffcfc)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
