### PR TITLE
✨ Add `GLWpfControl` to `SceneView`

### DIFF
--- a/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
+++ b/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
@@ -30,4 +30,9 @@
     </PackageReference>
     <PackageReference Include="System.IO.Abstractions" Version="19.2.29" />
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.ECS\FinalEngine.ECS.csproj" />
+    <ProjectReference Include="..\FinalEngine.Rendering\FinalEngine.Rendering.csproj" />
+  </ItemGroup>
 </Project>

--- a/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
+++ b/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
@@ -32,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\FinalEngine.ECS\FinalEngine.ECS.csproj" />
     <ProjectReference Include="..\FinalEngine.Rendering\FinalEngine.Rendering.csproj" />
   </ItemGroup>
 </Project>

--- a/FinalEngine.Editor.Common/GlobalSuppressions.cs
+++ b/FinalEngine.Editor.Common/GlobalSuppressions.cs
@@ -1,7 +1,6 @@
-// This file is used by Code Analysis to maintain SuppressMessage
-// attributes that are applied to this project.
-// Project-level suppressions either have no target or are given
-// a specific target and scoped to a namespace, type, member, etc.
+// <copyright file="GlobalSuppressions.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
 
 using System.Diagnostics.CodeAnalysis;
 

--- a/FinalEngine.Editor.Common/GlobalSuppressions.cs
+++ b/FinalEngine.Editor.Common/GlobalSuppressions.cs
@@ -1,0 +1,9 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Performance", "CA1848:Use the LoggerMessage delegates", Justification = "KISS")]
+[assembly: SuppressMessage("Usage", "CA2254:Template should be a static expression", Justification = "KISS")]

--- a/FinalEngine.Editor.Common/Services/Scenes/ISceneRenderer.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/ISceneRenderer.cs
@@ -1,0 +1,10 @@
+// <copyright file="ISceneRenderer.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Scenes;
+
+public interface ISceneRenderer
+{
+    void Render();
+}

--- a/FinalEngine.Editor.Common/Services/Scenes/ISceneRenderer.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/ISceneRenderer.cs
@@ -4,7 +4,13 @@
 
 namespace FinalEngine.Editor.Common.Services.Scenes;
 
+/// <summary>
+/// Defines an interface that renders a scene.
+/// </summary>
 public interface ISceneRenderer
 {
+    /// <summary>
+    /// Renders the scene.
+    /// </summary>
     void Render();
 }

--- a/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
@@ -8,15 +8,32 @@ using System;
 using System.Drawing;
 using FinalEngine.Rendering;
 
+/// <summary>
+/// Provides a standard implementation of an <see cref="ISceneRenderer"/>.
+/// </summary>
+/// <seealso cref="ISceneRenderer" />
 public sealed class SceneRenderer : ISceneRenderer
 {
+    /// <summary>
+    /// The render device.
+    /// </summary>
     private readonly IRenderDevice renderDevice;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SceneRenderer"/> class.
+    /// </summary>
+    /// <param name="renderDevice">
+    /// The render device.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="renderDevice"/> parameter cannot be null.
+    /// </exception>
     public SceneRenderer(IRenderDevice renderDevice)
     {
         this.renderDevice = renderDevice ?? throw new ArgumentNullException(nameof(renderDevice));
     }
 
+    /// <inheritdoc/>
     public void Render()
     {
         this.renderDevice.Clear(Color.FromArgb(255, 30, 30, 30));

--- a/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
@@ -1,0 +1,24 @@
+// <copyright file="SceneRenderer.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Scenes;
+
+using System;
+using System.Drawing;
+using FinalEngine.Rendering;
+
+public sealed class SceneRenderer : ISceneRenderer
+{
+    private readonly IRenderDevice renderDevice;
+
+    public SceneRenderer(IRenderDevice renderDevice)
+    {
+        this.renderDevice = renderDevice ?? throw new ArgumentNullException(nameof(renderDevice));
+    }
+
+    public void Render()
+    {
+        this.renderDevice.Clear(Color.FromArgb(255, 30, 30, 30));
+    }
+}

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -25,12 +25,8 @@ using FinalEngine.Editor.ViewModels.Docking.Tools.Scenes;
 using FinalEngine.Editor.ViewModels.Interactions;
 using FinalEngine.Editor.ViewModels.Services.Actions;
 using FinalEngine.Editor.ViewModels.Services.Factories.Layout;
-using FinalEngine.Extensions.Resources.Loaders.Audio;
-using FinalEngine.Extensions.Resources.Loaders.Shaders;
-using FinalEngine.Extensions.Resources.Loaders.Textures;
 using FinalEngine.Rendering;
 using FinalEngine.Rendering.OpenGL;
-using FinalEngine.Resources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -109,25 +105,6 @@ public partial class App : Application
         });
 
         services.AddSingleton<IRenderDevice, OpenGLRenderDevice>();
-
-        services.AddSingleton<IGPUResourceFactory>(x =>
-        {
-            return x.GetRequiredService<IRenderDevice>().Factory;
-        });
-
-        services.AddSingleton<IResourceManager>(x =>
-        {
-            var resourceManager = ResourceManager.Instance;
-
-            var fileSystem = x.GetRequiredService<IFileSystem>();
-            var gpuFactory = x.GetRequiredService<IGPUResourceFactory>();
-
-            resourceManager.RegisterLoader(new SoundResourceLoader(fileSystem));
-            resourceManager.RegisterLoader(new Texture2DResourceLoader(fileSystem, gpuFactory));
-            resourceManager.RegisterLoader(new ShaderResourceLoader(fileSystem, gpuFactory));
-
-            return resourceManager;
-        });
 
         services.AddSingleton<IFileSystem, FileSystem>();
 

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -7,10 +7,10 @@ namespace FinalEngine.Editor.Desktop;
 using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Windows;
-using CommunityToolkit.Mvvm.Messaging;
 using FinalEngine.Editor.Common.Extensions;
 using FinalEngine.Editor.Common.Services.Application;
 using FinalEngine.Editor.Common.Services.Environment;
+using FinalEngine.Editor.Common.Services.Scenes;
 using FinalEngine.Editor.Desktop.Services.Actions;
 using FinalEngine.Editor.Desktop.Services.Factories.Layout;
 using FinalEngine.Editor.Desktop.Views;
@@ -25,6 +25,12 @@ using FinalEngine.Editor.ViewModels.Docking.Tools.Scenes;
 using FinalEngine.Editor.ViewModels.Interactions;
 using FinalEngine.Editor.ViewModels.Services.Actions;
 using FinalEngine.Editor.ViewModels.Services.Factories.Layout;
+using FinalEngine.Extensions.Resources.Loaders.Audio;
+using FinalEngine.Extensions.Resources.Loaders.Shaders;
+using FinalEngine.Extensions.Resources.Loaders.Textures;
+using FinalEngine.Rendering;
+using FinalEngine.Rendering.OpenGL;
+using FinalEngine.Resources;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -102,11 +108,32 @@ public partial class App : Application
             builder.AddConsole().SetMinimumLevel(Debugger.IsAttached ? LogLevel.Debug : LogLevel.Information);
         });
 
+        services.AddSingleton<IRenderDevice, OpenGLRenderDevice>();
+
+        services.AddSingleton<IGPUResourceFactory>(x =>
+        {
+            return x.GetRequiredService<IRenderDevice>().Factory;
+        });
+
+        services.AddSingleton<IResourceManager>(x =>
+        {
+            var resourceManager = ResourceManager.Instance;
+
+            var fileSystem = x.GetRequiredService<IFileSystem>();
+            var gpuFactory = x.GetRequiredService<IGPUResourceFactory>();
+
+            resourceManager.RegisterLoader(new SoundResourceLoader(fileSystem));
+            resourceManager.RegisterLoader(new Texture2DResourceLoader(fileSystem, gpuFactory));
+            resourceManager.RegisterLoader(new ShaderResourceLoader(fileSystem, gpuFactory));
+
+            return resourceManager;
+        });
+
         services.AddSingleton<IFileSystem, FileSystem>();
 
-        services.AddSingleton<IMessenger>(WeakReferenceMessenger.Default);
         services.AddSingleton<IApplicationContext, ApplicationContext>();
         services.AddSingleton<IEnvironmentContext, EnvironmentContext>();
+        services.AddSingleton<ISceneRenderer, SceneRenderer>();
 
         services.AddFactory<IProjectExplorerToolViewModel, ProjectExplorerToolViewModel>();
         services.AddFactory<ISceneHierarchyToolViewModel, SceneHierarchyToolViewModel>();

--- a/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
+++ b/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
@@ -44,7 +44,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj" />
-    <ProjectReference Include="..\FinalEngine.Extensions.Resources\FinalEngine.Extensions.Resources.csproj" />
     <ProjectReference Include="..\FinalEngine.Rendering.OpenGL\FinalEngine.Rendering.OpenGL.csproj" />
   </ItemGroup>
 

--- a/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
+++ b/FinalEngine.Editor.Desktop/FinalEngine.Editor.Desktop.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Dirkster.AvalonDock" Version="4.72.0" />
     <PackageReference Include="Dirkster.AvalonDock.Themes.VS2013" Version="4.72.0" />
     <PackageReference Include="EventBinder" Version="2.5.2" />
+    <PackageReference Include="GLWpfControl" Version="1.0.0" />
     <PackageReference Include="MahApps.Metro" Version="2.4.10" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="7.0.3">
       <PrivateAssets>all</PrivateAssets>
@@ -43,6 +44,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\FinalEngine.Editor.ViewModels\FinalEngine.Editor.ViewModels.csproj" />
+    <ProjectReference Include="..\FinalEngine.Extensions.Resources\FinalEngine.Extensions.Resources.csproj" />
+    <ProjectReference Include="..\FinalEngine.Rendering.OpenGL\FinalEngine.Rendering.OpenGL.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml
@@ -1,11 +1,24 @@
-<UserControl x:Class="FinalEngine.Editor.Desktop.Views.Scenes.SceneView"
+<UserControl x:Name="sceneView"
+             x:Class="FinalEngine.Editor.Desktop.Views.Scenes.SceneView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="clr-namespace:FinalEngine.Editor.ViewModels.Docking.Panes.Scenes;assembly=FinalEngine.Editor.ViewModels"
+             xmlns:glwpf="clr-namespace:OpenTK.Wpf;assembly=GLWpfControl"
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance Type=vm:SceneViewPaneViewModel}">
     <Grid>
+        <glwpf:GLWpfControl x:Name="glWpfControl"
+                            RegisterToEventsDirectly="False"
+                            CanInvokeOnHandledEvents="False">
+            <glwpf:GLWpfControl.Settings>
+                <glwpf:GLWpfControlSettings MajorVersion="4"
+                                            MinorVersion="5"
+                                            GraphicsContextFlags="ForwardCompatible"
+                                            GraphicsProfile="Core"
+                                            RenderContinuously="True" />
+            </glwpf:GLWpfControl.Settings>
+        </glwpf:GLWpfControl>
     </Grid>
 </UserControl>

--- a/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml
@@ -1,5 +1,4 @@
-<UserControl x:Name="sceneView"
-             x:Class="FinalEngine.Editor.Desktop.Views.Scenes.SceneView"
+<UserControl x:Class="FinalEngine.Editor.Desktop.Views.Scenes.SceneView"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"

--- a/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:eb="clr-namespace:EventBinder;assembly=EventBinder"
              xmlns:vm="clr-namespace:FinalEngine.Editor.ViewModels.Docking.Panes.Scenes;assembly=FinalEngine.Editor.ViewModels"
              xmlns:glwpf="clr-namespace:OpenTK.Wpf;assembly=GLWpfControl"
              mc:Ignorable="d"
@@ -11,7 +12,8 @@
     <Grid>
         <glwpf:GLWpfControl x:Name="glWpfControl"
                             RegisterToEventsDirectly="False"
-                            CanInvokeOnHandledEvents="False">
+                            CanInvokeOnHandledEvents="False"
+                            Render="{eb:EventBinding RenderCommand.Execute, `null`}">
             <glwpf:GLWpfControl.Settings>
                 <glwpf:GLWpfControlSettings MajorVersion="4"
                                             MinorVersion="5"

--- a/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml.cs
+++ b/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml.cs
@@ -4,7 +4,6 @@
 
 namespace FinalEngine.Editor.Desktop.Views.Scenes;
 
-using System.Diagnostics;
 using System.Windows.Controls;
 
 /// <summary>
@@ -12,8 +11,6 @@ using System.Windows.Controls;
 /// </summary>
 public partial class SceneView : UserControl
 {
-    private static readonly Stopwatch stopwatch = Stopwatch.StartNew();
-
     /// <summary>
     /// Initializes a new instance of the <see cref="SceneView"/> class.
     /// </summary>

--- a/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml.cs
+++ b/FinalEngine.Editor.Desktop/Views/Scenes/SceneView.xaml.cs
@@ -4,6 +4,7 @@
 
 namespace FinalEngine.Editor.Desktop.Views.Scenes;
 
+using System.Diagnostics;
 using System.Windows.Controls;
 
 /// <summary>
@@ -11,11 +12,14 @@ using System.Windows.Controls;
 /// </summary>
 public partial class SceneView : UserControl
 {
+    private static readonly Stopwatch stopwatch = Stopwatch.StartNew();
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SceneView"/> class.
     /// </summary>
     public SceneView()
     {
         this.InitializeComponent();
+        this.glWpfControl.Start();
     }
 }

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/ISceneViewPaneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/ISceneViewPaneViewModel.cs
@@ -12,5 +12,14 @@ using System.Windows.Input;
 /// <seealso cref="IPaneViewModel" />
 public interface ISceneViewPaneViewModel : IPaneViewModel
 {
+    /// <summary>
+    /// Gets the render command.
+    /// </summary>
+    /// <value>
+    /// The render command.
+    /// </value>
+    /// <remarks>
+    /// The <see cref="RenderCommand"/> is used to render the currently active scene.
+    /// </remarks>
     ICommand RenderCommand { get; }
 }

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/ISceneViewPaneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/ISceneViewPaneViewModel.cs
@@ -4,10 +4,13 @@
 
 namespace FinalEngine.Editor.ViewModels.Docking.Panes.Scenes;
 
+using System.Windows.Input;
+
 /// <summary>
 /// Defines an interface that represents a model of the scene view pane.
 /// </summary>
 /// <seealso cref="IPaneViewModel" />
 public interface ISceneViewPaneViewModel : IPaneViewModel
 {
+    ICommand RenderCommand { get; }
 }

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/SceneViewPaneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/SceneViewPaneViewModel.cs
@@ -17,10 +17,14 @@ using Microsoft.Extensions.Logging;
 /// <seealso cref="ISceneViewPaneViewModel" />
 public sealed class SceneViewPaneViewModel : PaneViewModelBase, ISceneViewPaneViewModel
 {
-    private readonly ILogger<SceneViewPaneViewModel> logger;
-
+    /// <summary>
+    /// The scene renderer, used to render the current scene.
+    /// </summary>
     private readonly ISceneRenderer sceneRenderer;
 
+    /// <summary>
+    /// The render command, used to render the current scene.
+    /// </summary>
     private ICommand? renderCommand;
 
     /// <summary>
@@ -29,24 +33,35 @@ public sealed class SceneViewPaneViewModel : PaneViewModelBase, ISceneViewPaneVi
     /// <param name="logger">
     /// The logger.
     /// </param>
+    /// <param name="sceneRenderer">
+    /// The scene renderer used to render the currently active scene.
+    /// </param>
     public SceneViewPaneViewModel(
         ILogger<SceneViewPaneViewModel> logger,
         ISceneRenderer sceneRenderer)
     {
-        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        if (logger == null)
+        {
+            throw new ArgumentNullException(nameof(logger));
+        }
+
         this.sceneRenderer = sceneRenderer ?? throw new ArgumentNullException(nameof(sceneRenderer));
 
         this.Title = "Scene View";
         this.ContentID = "SceneView";
 
-        this.logger.LogInformation($"Initializing {this.Title}...");
+        logger.LogInformation($"Initializing {this.Title}...");
     }
 
+    /// <inheritdoc/>
     public ICommand RenderCommand
     {
         get { return this.renderCommand ??= new RelayCommand(this.Render); }
     }
 
+    /// <summary>
+    /// Renders the currently active scene.
+    /// </summary>
     private void Render()
     {
         this.sceneRenderer.Render();

--- a/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/SceneViewPaneViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Docking/Panes/Scenes/SceneViewPaneViewModel.cs
@@ -5,6 +5,9 @@
 namespace FinalEngine.Editor.ViewModels.Docking.Panes.Scenes;
 
 using System;
+using System.Windows.Input;
+using CommunityToolkit.Mvvm.Input;
+using FinalEngine.Editor.Common.Services.Scenes;
 using Microsoft.Extensions.Logging;
 
 /// <summary>
@@ -14,22 +17,38 @@ using Microsoft.Extensions.Logging;
 /// <seealso cref="ISceneViewPaneViewModel" />
 public sealed class SceneViewPaneViewModel : PaneViewModelBase, ISceneViewPaneViewModel
 {
+    private readonly ILogger<SceneViewPaneViewModel> logger;
+
+    private readonly ISceneRenderer sceneRenderer;
+
+    private ICommand? renderCommand;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="SceneViewPaneViewModel"/> class.
     /// </summary>
     /// <param name="logger">
     /// The logger.
     /// </param>
-    public SceneViewPaneViewModel(ILogger<SceneViewPaneViewModel> logger)
+    public SceneViewPaneViewModel(
+        ILogger<SceneViewPaneViewModel> logger,
+        ISceneRenderer sceneRenderer)
     {
-        if (logger == null)
-        {
-            throw new ArgumentNullException(nameof(logger));
-        }
+        this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        this.sceneRenderer = sceneRenderer ?? throw new ArgumentNullException(nameof(sceneRenderer));
 
         this.Title = "Scene View";
         this.ContentID = "SceneView";
 
-        logger.LogInformation($"Initializing {this.Title}...");
+        this.logger.LogInformation($"Initializing {this.Title}...");
+    }
+
+    public ICommand RenderCommand
+    {
+        get { return this.renderCommand ??= new RelayCommand(this.Render); }
+    }
+
+    private void Render()
+    {
+        this.sceneRenderer.Render();
     }
 }

--- a/FinalEngine.Examples.Game/Program.cs
+++ b/FinalEngine.Examples.Game/Program.cs
@@ -73,7 +73,7 @@ internal static class Program
         var gameTime = new GameTime(120.0d);
 
         resourceManager.RegisterLoader(new SoundResourceLoader(fileSystem));
-        resourceManager.RegisterLoader(new ShaderResourceLoader(renderDevice.Factory, fileSystem));
+        resourceManager.RegisterLoader(new ShaderResourceLoader(fileSystem, renderDevice.Factory));
         resourceManager.RegisterLoader(new Texture2DResourceLoader(fileSystem, renderDevice.Factory));
 
         displayManager.ChangeResolution(DisplayResolution.HighDefinition);

--- a/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
+++ b/FinalEngine.Extensions.Resources/Loaders/Shaders/ShaderResourceLoader.cs
@@ -29,16 +29,16 @@ public sealed class ShaderResourceLoader : ResourceLoaderBase<IShader>
     /// <summary>
     /// Initializes a new instance of the <see cref="ShaderResourceLoader"/> class.
     /// </summary>
-    /// <param name="factory">
-    /// The GPU resource factory, used to load shaders into memory.
-    /// </param>
     /// <param name="fileSystem">
     /// The file system, used to load shader source code into memory.
+    /// </param>
+    /// <param name="factory">
+    /// The GPU resource factory, used to load shaders into memory.
     /// </param>
     /// <exception cref="ArgumentNullException">
     /// The specified <paramref name="factory"/> or <paramref name="fileSystem"/> parameter cannot be null.
     /// </exception>
-    public ShaderResourceLoader(IGPUResourceFactory factory, IFileSystem fileSystem)
+    public ShaderResourceLoader(IFileSystem fileSystem, IGPUResourceFactory factory)
     {
         this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
         this.fileSystem = fileSystem ?? throw new ArgumentNullException(nameof(fileSystem));

--- a/FinalEngine.Tests/Editor/Common/Services/Rendering/SceneRendererTests.cs
+++ b/FinalEngine.Tests/Editor/Common/Services/Rendering/SceneRendererTests.cs
@@ -1,0 +1,47 @@
+// <copyright file="SceneRendererTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.Common.Services.Rendering;
+
+using System;
+using System.Drawing;
+using FinalEngine.Editor.Common.Services.Scenes;
+using FinalEngine.Rendering;
+using Moq;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class SceneRendererTests
+{
+    private Mock<IRenderDevice> renderDevice;
+
+    private SceneRenderer sceneRenderer;
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenRenderDeviceIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new SceneRenderer(null);
+        });
+    }
+
+    [Test]
+    public void RenderShouldInvokeRenderDeviceClearWhenInvoked()
+    {
+        // Act
+        this.sceneRenderer.Render();
+
+        // Assert
+        this.renderDevice.Verify(x => x.Clear(Color.FromArgb(255, 30, 30, 30), 1, 0), Times.Once);
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.renderDevice = new Mock<IRenderDevice>();
+        this.sceneRenderer = new SceneRenderer(this.renderDevice.Object);
+    }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/Docking/Panes/Scenes/SceneViewPaneViewModelTests.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Docking/Panes/Scenes/SceneViewPaneViewModelTests.cs
@@ -5,6 +5,7 @@
 namespace FinalEngine.Tests.Editor.ViewModels.Docking.Panes.Scenes;
 
 using System;
+using FinalEngine.Editor.Common.Services.Scenes;
 using FinalEngine.Editor.ViewModels.Docking.Panes.Scenes;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -14,6 +15,8 @@ using NUnit.Framework;
 public sealed class SceneViewPaneViewModelTests
 {
     private Mock<ILogger<SceneViewPaneViewModel>> logger;
+
+    private Mock<ISceneRenderer> sceneRenderer;
 
     private SceneViewPaneViewModel viewModel;
 
@@ -48,14 +51,34 @@ public sealed class SceneViewPaneViewModelTests
     {
         Assert.Throws<ArgumentNullException>(() =>
         {
-            new SceneViewPaneViewModel(null);
+            new SceneViewPaneViewModel(null, this.sceneRenderer.Object);
         });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenSceneRendererIsNull()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new SceneViewPaneViewModel(this.logger.Object, null);
+        });
+    }
+
+    [Test]
+    public void RenderCommandExecuteShouldInvokeSceneRendererRenderWhenInvoked()
+    {
+        // Act
+        this.viewModel.RenderCommand.Execute(null);
+
+        // Assert
+        this.sceneRenderer.Verify(x => x.Render(), Times.Once);
     }
 
     [SetUp]
     public void Setup()
     {
         this.logger = new Mock<ILogger<SceneViewPaneViewModel>>();
-        this.viewModel = new SceneViewPaneViewModel(this.logger.Object);
+        this.sceneRenderer = new Mock<ISceneRenderer>();
+        this.viewModel = new SceneViewPaneViewModel(this.logger.Object, this.sceneRenderer.Object);
     }
 }

--- a/FinalEngine.Tests/Extensions/Resources/Loaders/Shaders/ShaderResourceLoaderTests.cs
+++ b/FinalEngine.Tests/Extensions/Resources/Loaders/Shaders/ShaderResourceLoaderTests.cs
@@ -30,7 +30,7 @@ public sealed class ShaderResourceLoaderTests
         // Act and assert
         Assert.Throws<ArgumentNullException>(() =>
         {
-            new ShaderResourceLoader(null, this.fileSystem);
+            new ShaderResourceLoader(this.fileSystem, null);
         });
     }
 
@@ -40,7 +40,7 @@ public sealed class ShaderResourceLoaderTests
         // Act and assert
         Assert.Throws<ArgumentNullException>(() =>
         {
-            new ShaderResourceLoader(this.factory.Object, null);
+            new ShaderResourceLoader(null, this.factory.Object);
         });
     }
 
@@ -149,6 +149,6 @@ public sealed class ShaderResourceLoaderTests
 
         this.factory.Setup(x => x.CreateShader(It.IsAny<PipelineTarget>(), It.IsAny<string>())).Returns(this.shader.Object);
 
-        this.loader = new ShaderResourceLoader(this.factory.Object, this.fileSystem);
+        this.loader = new ShaderResourceLoader(this.fileSystem, this.factory.Object);
     }
 }

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.2260.0")]
-[assembly: AssemblyFileVersion("2023.3.2260.0")]
+[assembly: AssemblyVersion("2023.3.2267.0")]
+[assembly: AssemblyFileVersion("2023.3.2267.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.2274.0")]
-[assembly: AssemblyFileVersion("2023.3.2273.0")]
+[assembly: AssemblyVersion("2023.3.2334.0")]
+[assembly: AssemblyFileVersion("2023.3.2333.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.1924.0")]
-[assembly: AssemblyFileVersion("2023.3.1924.0")]
+[assembly: AssemblyVersion("2023.3.2260.0")]
+[assembly: AssemblyFileVersion("2023.3.2260.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.2267.0")]
-[assembly: AssemblyFileVersion("2023.3.2267.0")]
+[assembly: AssemblyVersion("2023.3.2274.0")]
+[assembly: AssemblyFileVersion("2023.3.2273.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else


### PR DESCRIPTION
# Description

- Added `GLWpfControl` to `SceneView`
- Created a `SceneRenderer` service to handle rendering of scenes (currently it just clears the view to a dark color).
- Uploaded an unlisted `GLWpfControl` NuGet package until the official package can be updated:
  - https://github.com/opentk/GLWpfControl/pull/115
  - https://github.com/opentk/GLWpfControl/pull/106
- Removed `WeakReferenceMessenger` from the IoC container as we're not using it.

Fixes #242 

## Dependencies

- [GLWpfControl 1.0.0 - Unlisted](https://www.nuget.org/packages/GLWpfControl/).

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I added unit tests to accommodate my changes as well as ensured that a simple triangle could be rendered using immediate mode OpenGL (this has been removed as it's not a requirement for the issue). I also made sure that events were still being triggered by the main application as originally there were some issues but it looks like they've been resolved.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ, 32GB, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Proposed Design

### Scene Renderer

The scene renderer is responsible for rendering the currently active scene. Right now it simply clears the view to a dark color. You should not but any game-update logic in here. This can instead be handled by the `SceneViewPaneViewModel` with some other service if required.

```csharp
/// <summary>
/// Defines an interface that renders a scene.
/// </summary>
public interface ISceneRenderer
{
    /// <summary>
    /// Renders the scene.
    /// </summary>
    void Render();
}

```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
