### PR TITLE
✨ Entity Creation and Scene Management

### DIFF
--- a/FinalEngine.ECS/IEntityWorld.cs
+++ b/FinalEngine.ECS/IEntityWorld.cs
@@ -9,7 +9,7 @@ using System;
 /// <summary>
 ///   Defines an interface that creates the connection between <see cref="Entity"/> and <see cref="EntitySystemBase"/>.
 /// </summary>
-public interface IEntityWorld
+public interface IEntityWorld : IEntitySystemsProcessor
 {
     /// <summary>
     ///   Adds the specified <paramref name="entity"/> to this <see cref="IEntityWorld"/>.

--- a/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
+++ b/FinalEngine.Editor.Common/FinalEngine.Editor.Common.csproj
@@ -32,6 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\FinalEngine.ECS\FinalEngine.ECS.csproj" />
     <ProjectReference Include="..\FinalEngine.Rendering\FinalEngine.Rendering.csproj" />
   </ItemGroup>
 </Project>

--- a/FinalEngine.Editor.Common/Models/Scenes/IScene.cs
+++ b/FinalEngine.Editor.Common/Models/Scenes/IScene.cs
@@ -1,0 +1,35 @@
+// <copyright file="IScene.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Models.Scenes;
+
+using System.Collections.Generic;
+using FinalEngine.ECS;
+
+/// <summary>
+/// Defines an interface that represents a scene.
+/// </summary>
+public interface IScene
+{
+    /// <summary>
+    /// Gets the entities contained within this scene.
+    /// </summary>
+    /// <value>
+    /// The entities contained within this scene.
+    /// </value>
+    IReadOnlyCollection<Entity> Entities { get; }
+
+    /// <summary>
+    /// Adds the specified <paramref name="entity"/> to the scene.
+    /// </summary>
+    /// <param name="entity">
+    /// The entity to be added.
+    /// </param>
+    void AddEntity(Entity entity);
+
+    /// <summary>
+    /// Renders the scene, processing all rendering systems.
+    /// </summary>
+    void Render();
+}

--- a/FinalEngine.Editor.Common/Models/Scenes/Scene.cs
+++ b/FinalEngine.Editor.Common/Models/Scenes/Scene.cs
@@ -1,0 +1,38 @@
+// <copyright file="Scene.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Models.Scenes;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using FinalEngine.ECS;
+
+public sealed class Scene
+{
+    private readonly ObservableCollection<Entity> entities;
+
+    private readonly IEntityWorld world;
+
+    public Scene(IEntityWorld world)
+    {
+        this.world = world ?? throw new ArgumentNullException(nameof(world));
+    }
+
+    public IReadOnlyCollection<Entity> Entities
+    {
+        get { return this.entities; }
+    }
+
+    public void AddEntity(Entity entity)
+    {
+        if (entity == null)
+        {
+            throw new ArgumentNullException(nameof(entity));
+        }
+
+        this.world.AddEntity(entity);
+        this.entities.Add(entity);
+    }
+}

--- a/FinalEngine.Editor.Common/Models/Scenes/Scene.cs
+++ b/FinalEngine.Editor.Common/Models/Scenes/Scene.cs
@@ -9,22 +9,46 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using FinalEngine.ECS;
 
-public sealed class Scene
+/// <summary>
+/// Represents a scene that contains a collection of entities and systems.
+/// </summary>
+public sealed class Scene : IScene
 {
+    /// <summary>
+    /// The entities contained within the scene.
+    /// </summary>
     private readonly ObservableCollection<Entity> entities;
 
+    /// <summary>
+    /// The underlying entity world that contains all the scenes entities and systems.
+    /// </summary>
     private readonly IEntityWorld world;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Scene"/> class.
+    /// </summary>
+    /// <param name="world">
+    /// The entity world to be associated with this scene.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="world"/> parameter cannot be null.
+    /// </exception>
     public Scene(IEntityWorld world)
     {
         this.world = world ?? throw new ArgumentNullException(nameof(world));
+        this.entities = new ObservableCollection<Entity>();
     }
 
+    /// <inheritdoc/>
     public IReadOnlyCollection<Entity> Entities
     {
         get { return this.entities; }
     }
 
+    /// <inheritdoc/>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="entity"/> parameter cannot be null.
+    /// </exception>
     public void AddEntity(Entity entity)
     {
         if (entity == null)
@@ -34,5 +58,11 @@ public sealed class Scene
 
         this.world.AddEntity(entity);
         this.entities.Add(entity);
+    }
+
+    /// <inheritdoc/>
+    public void Render()
+    {
+        this.world.ProcessAll(GameLoopType.Render);
     }
 }

--- a/FinalEngine.Editor.Common/Services/Scenes/ISceneManager.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/ISceneManager.cs
@@ -1,0 +1,24 @@
+// <copyright file="ISceneManager.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Scenes;
+
+using FinalEngine.Editor.Common.Models.Scenes;
+
+/// <summary>
+/// Defines an interface that represents a <see cref="Scene"/> manager.
+/// </summary>
+public interface ISceneManager
+{
+    /// <summary>
+    /// Gets the currently active/loaded scene.
+    /// </summary>
+    /// <value>
+    /// The active/loaded scene.
+    /// </value>
+    /// <remarks>
+    /// The <see cref="ActiveScene"/> property should never return <c>null</c>, an empty scene should be created on application startup.
+    /// </remarks>
+    IScene ActiveScene { get; }
+}

--- a/FinalEngine.Editor.Common/Services/Scenes/SceneManager.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/SceneManager.cs
@@ -1,0 +1,32 @@
+// <copyright file="SceneManager.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.Common.Services.Scenes;
+
+using System;
+using FinalEngine.Editor.Common.Models.Scenes;
+
+/// <summary>
+/// Provides a standard implementation of an <see cref="ISceneManager"/>.
+/// </summary>
+/// <seealso cref="ISceneManager" />
+public sealed class SceneManager : ISceneManager
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SceneManager"/> class.
+    /// </summary>
+    /// <param name="scene">
+    /// The scene to be managed.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="scene"/> parameter cannot be null.
+    /// </exception>
+    public SceneManager(IScene scene)
+    {
+        this.ActiveScene = scene ?? throw new ArgumentNullException(nameof(scene));
+    }
+
+    /// <inheritdoc/>
+    public IScene ActiveScene { get; }
+}

--- a/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
+++ b/FinalEngine.Editor.Common/Services/Scenes/SceneRenderer.cs
@@ -20,22 +20,32 @@ public sealed class SceneRenderer : ISceneRenderer
     private readonly IRenderDevice renderDevice;
 
     /// <summary>
+    /// The scene manager, used to retrieve and render the currently active scene.
+    /// </summary>
+    private readonly ISceneManager sceneManager;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="SceneRenderer"/> class.
     /// </summary>
     /// <param name="renderDevice">
     /// The render device.
     /// </param>
+    /// <param name="sceneManager">
+    /// The scene manager, used to retrieve and render the currently active scene.
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// The specified <paramref name="renderDevice"/> parameter cannot be null.
     /// </exception>
-    public SceneRenderer(IRenderDevice renderDevice)
+    public SceneRenderer(IRenderDevice renderDevice, ISceneManager sceneManager)
     {
         this.renderDevice = renderDevice ?? throw new ArgumentNullException(nameof(renderDevice));
+        this.sceneManager = sceneManager ?? throw new ArgumentNullException(nameof(sceneManager));
     }
 
     /// <inheritdoc/>
     public void Render()
     {
         this.renderDevice.Clear(Color.FromArgb(255, 30, 30, 30));
+        this.sceneManager.ActiveScene.Render();
     }
 }

--- a/FinalEngine.Editor.Desktop/App.xaml.cs
+++ b/FinalEngine.Editor.Desktop/App.xaml.cs
@@ -7,7 +7,9 @@ namespace FinalEngine.Editor.Desktop;
 using System.Diagnostics;
 using System.IO.Abstractions;
 using System.Windows;
+using FinalEngine.ECS;
 using FinalEngine.Editor.Common.Extensions;
+using FinalEngine.Editor.Common.Models.Scenes;
 using FinalEngine.Editor.Common.Services.Application;
 using FinalEngine.Editor.Common.Services.Environment;
 using FinalEngine.Editor.Common.Services.Scenes;
@@ -104,13 +106,17 @@ public partial class App : Application
             builder.AddConsole().SetMinimumLevel(Debugger.IsAttached ? LogLevel.Debug : LogLevel.Information);
         });
 
+        services.AddTransient<IEntityWorld, EntityWorld>();
         services.AddSingleton<IRenderDevice, OpenGLRenderDevice>();
 
         services.AddSingleton<IFileSystem, FileSystem>();
 
+        services.AddTransient<Scene>();
+
         services.AddSingleton<IApplicationContext, ApplicationContext>();
         services.AddSingleton<IEnvironmentContext, EnvironmentContext>();
         services.AddSingleton<ISceneRenderer, SceneRenderer>();
+        services.AddSingleton<ISceneManager, SceneManager>();
 
         services.AddFactory<IProjectExplorerToolViewModel, ProjectExplorerToolViewModel>();
         services.AddFactory<ISceneHierarchyToolViewModel, SceneHierarchyToolViewModel>();

--- a/FinalEngine.Tests/Editor/Common/Models/Scenes/SceneTests.cs
+++ b/FinalEngine.Tests/Editor/Common/Models/Scenes/SceneTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="SceneTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.Common.Models.Scenes;
+
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using FinalEngine.ECS;
+using FinalEngine.Editor.Common.Models.Scenes;
+using Moq;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class SceneTests
+{
+    private Scene scene;
+
+    private Mock<IEntityWorld> world;
+
+    [Test]
+    public void AddEntityShouldAddEntityToEntitiesWhenInvoked()
+    {
+        // Arrange
+        var entity = new Entity();
+
+        // Act
+        this.scene.AddEntity(entity);
+
+        // Assert
+        Assert.That(this.scene.Entities.FirstOrDefault(), Is.SameAs(entity));
+    }
+
+    [Test]
+    public void AddEntityShouldAddEntityToEntityWorldWhenInvoked()
+    {
+        // Arrange
+        var entity = new Entity();
+
+        // Act
+        this.scene.AddEntity(entity);
+
+        // Assert
+        this.world.Verify(x => x.AddEntity(entity), Times.Once);
+    }
+
+    [Test]
+    public void AddEntityShouldThrowArgumentNullExceptionWhenEntityIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            this.scene.AddEntity(null);
+        });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenWorldIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new Scene(null);
+        });
+    }
+
+    [Test]
+    public void EntitiesShouldNotReturnNullWhenInvoked()
+    {
+        // Act
+        var actual = this.scene.Entities;
+
+        // Assert
+        Assert.That(actual, Is.Not.Null);
+    }
+
+    [Test]
+    public void EntitiesShouldReturnReadOnlyObservableCollectionWhenInvoked()
+    {
+        // Act
+        var actual = this.scene.Entities;
+
+        // Assert
+        Assert.That(actual, Is.InstanceOf<ObservableCollection<Entity>>());
+    }
+
+    [Test]
+    public void RenderShouldInvokeWorldProcessAllRenderWhenInvoked()
+    {
+        // Act
+        this.scene.Render();
+
+        // Assert
+        this.world.Verify(x => x.ProcessAll(GameLoopType.Render), Times.Once);
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.world = new Mock<IEntityWorld>();
+        this.scene = new Scene(this.world.Object);
+    }
+}

--- a/FinalEngine.Tests/Editor/Common/Services/Rendering/SceneManagerTests.cs
+++ b/FinalEngine.Tests/Editor/Common/Services/Rendering/SceneManagerTests.cs
@@ -1,0 +1,56 @@
+// <copyright file="SceneManagerTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.Common.Services.Rendering;
+
+using System;
+using FinalEngine.Editor.Common.Models.Scenes;
+using FinalEngine.Editor.Common.Services.Scenes;
+using Moq;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class SceneManagerTests
+{
+    private Mock<IScene> scene;
+
+    private SceneManager sceneManager;
+
+    [Test]
+    public void ActiveSceneShouldNotBeenNullWhenInvoked()
+    {
+        // Act
+        var actual = this.sceneManager.ActiveScene;
+
+        // Assert
+        Assert.That(actual, Is.Not.Null);
+    }
+
+    [Test]
+    public void ActiveSceneShouldReturnSceneWhenInvoked()
+    {
+        // Act
+        var actual = this.sceneManager.ActiveScene;
+
+        // Assert
+        Assert.That(actual, Is.SameAs(this.scene.Object));
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenSceneIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new SceneManager(null);
+        });
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.scene = new Mock<IScene>();
+        this.sceneManager = new SceneManager(this.scene.Object);
+    }
+}

--- a/FinalEngine.Tests/Editor/Common/Services/Rendering/SceneRendererTests.cs
+++ b/FinalEngine.Tests/Editor/Common/Services/Rendering/SceneRendererTests.cs
@@ -6,6 +6,7 @@ namespace FinalEngine.Tests.Editor.Common.Services.Rendering;
 
 using System;
 using System.Drawing;
+using FinalEngine.Editor.Common.Models.Scenes;
 using FinalEngine.Editor.Common.Services.Scenes;
 using FinalEngine.Rendering;
 using Moq;
@@ -16,6 +17,10 @@ public sealed class SceneRendererTests
 {
     private Mock<IRenderDevice> renderDevice;
 
+    private Mock<IScene> scene;
+
+    private Mock<ISceneManager> sceneManager;
+
     private SceneRenderer sceneRenderer;
 
     [Test]
@@ -24,8 +29,28 @@ public sealed class SceneRendererTests
         // Act and assert
         Assert.Throws<ArgumentNullException>(() =>
         {
-            new SceneRenderer(null);
+            new SceneRenderer(null, this.sceneManager.Object);
         });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenSceneManagerIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new SceneRenderer(this.renderDevice.Object, null);
+        });
+    }
+
+    [Test]
+    public void RenderShouldInvokeActiveSceneRenderWhenInvoked()
+    {
+        // Act
+        this.sceneRenderer.Render();
+
+        // Assert
+        this.scene.Verify(x => x.Render(), Times.Once);
     }
 
     [Test]
@@ -41,7 +66,12 @@ public sealed class SceneRendererTests
     [SetUp]
     public void Setup()
     {
+        this.sceneManager = new Mock<ISceneManager>();
         this.renderDevice = new Mock<IRenderDevice>();
-        this.sceneRenderer = new SceneRenderer(this.renderDevice.Object);
+        this.scene = new Mock<IScene>();
+
+        this.sceneManager.SetupGet(x => x.ActiveScene).Returns(this.scene.Object);
+
+        this.sceneRenderer = new SceneRenderer(this.renderDevice.Object, this.sceneManager.Object);
     }
 }

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.2398.0")]
-[assembly: AssemblyFileVersion("2023.3.2397.0")]
+[assembly: AssemblyVersion("2023.3.2402.0")]
+[assembly: AssemblyFileVersion("2023.3.2401.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.2384.0")]
-[assembly: AssemblyFileVersion("2023.3.2383.0")]
+[assembly: AssemblyVersion("2023.3.2398.0")]
+[assembly: AssemblyFileVersion("2023.3.2397.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.2334.0")]
-[assembly: AssemblyFileVersion("2023.3.2333.0")]
+[assembly: AssemblyVersion("2023.3.2384.0")]
+[assembly: AssemblyFileVersion("2023.3.2383.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else


### PR DESCRIPTION
# Description

This PR produces the features described in issue #244:

- Created an `ISceneManager` that provides `readonly` access to the currently active/loaded scene.
- Create a `Scene` model that provides the ability to add an entity to the _transient_ injected `IEntityWorld` service.
  - The model provides access to the currently added entities via a `readonly` collection for use with view models.
  - The model also has a `Render` method that simply ensures that all systems that have a execution type of `Render` will be processed.
- The `SceneRenderer` has been updated to render the currently active/loaded `Scene` via the `ISceneManager`.

Closes #244

## Dependencies

This PR introduces no new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I have provided unit tests for all testable changes I've made. Final Code Coverage is showing 100% code coverage (obviously excluding any `ExcludeFromCodeCoverage` attributes). All unit tests pass locally on my machine. I've done my best to ensure that this feature is implemented correctly but I will not know until #248 is implemented.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ, 16GB RAM, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Proposed Design

### Scene Manager

The `ISceneManager` service is provided to access the currently active/loaded `Scene`. Final Engine doesn't support creating, loading or saving new scenes yet so this is likely to be added in the future. But for now, it is simply an interface to provide access to a `Scene` model. Currently, a _transient_ scene is passed into the `ISceneManager` implementation on application startup using the IoC container. This will likely be adjusted in the near future.

```csharp
public interface ISceneManager
{
    IScene ActiveScene { get; }
}
```

### Scenes

A `Scene` currently provides a way to add entities to an `IEntityWorld` (_transient_) via dependency injection. In the future a `Scene` will have the ability to serialized and de-serialized to allow for saving and loading of scenes. The `Scene` model also provides a `Render` function which simply invokes `world.ProcessAll(GameLoopType.Render)` to process all registered entity systems.

The `Scene` model also exposes a `readonly` collection of entities that will be accessed by the view models implemented in #248 when we address the front-end UI logic. An entity is added to both the injected `IEntityWorld` service and the collection that is initialized in the models constructor. The reasoning for this design decision is to make sure that the end-user cannot enumerate over an entities components as that is a job an entity system.

```csharp
/// <summary>
/// Defines an interface that represents a scene.
/// </summary>
public interface IScene
{
    /// <summary>
    /// Gets the entities contained within this scene.
    /// </summary>
    /// <value>
    /// The entities contained within this scene.
    /// </value>
    IReadOnlyCollection<Entity> Entities { get; }

    /// <summary>
    /// Adds the specified <paramref name="entity"/> to the scene.
    /// </summary>
    /// <param name="entity">
    /// The entity to be added.
    /// </param>
    void AddEntity(Entity entity);

    /// <summary>
    /// Renders the scene, processing all rendering systems.
    /// </summary>
    void Render();
}
```

## Possible Issues

I'm sure there will be some issue that will arise and can be addressed in the future but for now I think this is mostly boilerplate code. Most things I can think of are UI specific and should not be listed here and instead will be addressed when #248 is implemented.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
