### PR TITLE
✨ Implement Component Property Management Logic in Entity Inspector

### DIFF
--- a/FinalEngine.ECS.Components/Core/TagComponent.cs
+++ b/FinalEngine.ECS.Components/Core/TagComponent.cs
@@ -7,14 +7,14 @@ namespace FinalEngine.ECS.Components.Core;
 /// <summary>
 /// Provides a component that represents a name or tag for an <see cref="Entity"/>.
 /// </summary>
-/// <seealso cref="IComponent" />
-public sealed class TagComponent : IComponent
+/// <seealso cref="IEntityComponent" />
+public sealed class TagComponent : IEntityComponent
 {
     /// <summary>
-    /// Gets or sets the tag.
+    /// Gets or sets another tag.
     /// </summary>
     /// <value>
-    /// The tag.
+    /// Another tag.
     /// </value>
     public string? Tag { get; set; }
 }

--- a/FinalEngine.ECS.Components/Core/TagComponent.cs
+++ b/FinalEngine.ECS.Components/Core/TagComponent.cs
@@ -11,10 +11,10 @@ namespace FinalEngine.ECS.Components.Core;
 public sealed class TagComponent : IEntityComponent
 {
     /// <summary>
-    /// Gets or sets another tag.
+    /// Gets or sets the tag.
     /// </summary>
     /// <value>
-    /// Another tag.
+    /// The tag.
     /// </value>
     public string? Tag { get; set; }
 }

--- a/FinalEngine.ECS/Entity.cs
+++ b/FinalEngine.ECS/Entity.cs
@@ -33,6 +33,17 @@ public class Entity : DynamicObject, IReadOnlyEntity
     }
 
     /// <summary>
+    /// Gets the components attached to this <see cref="Entity"/>.
+    /// </summary>
+    /// <value>
+    /// The components attached to this <see cref="Entity"/>.
+    /// </value>
+    public ICollection<IComponent> Components
+    {
+        get { return this.typeToComponentMap.Values; }
+    }
+
+    /// <summary>
     /// Gets the unique identifier.
     /// </summary>
     /// <value>

--- a/FinalEngine.ECS/Entity.cs
+++ b/FinalEngine.ECS/Entity.cs
@@ -9,16 +9,16 @@ using System.Collections.Generic;
 using System.Dynamic;
 
 /// <summary>
-///   Provides a container for <see cref="IComponent"/> s that can be, added, removed or accessed during runtime through an <see cref="EntitySystemBase"/>.
+///   Provides a container for <see cref="IEntityComponent"/> s that can be, added, removed or accessed during runtime through an <see cref="EntitySystemBase"/>.
 /// </summary>
 /// <seealso cref="DynamicObject"/>
 /// <seealso cref="IReadOnlyEntity"/>
 public class Entity : DynamicObject, IReadOnlyEntity
 {
     /// <summary>
-    ///   Represents a type to <see cref="IComponent"/> map.
+    ///   Represents a type to <see cref="IEntityComponent"/> map.
     /// </summary>
-    private readonly IDictionary<Type, IComponent> typeToComponentMap;
+    private readonly IDictionary<Type, IEntityComponent> typeToComponentMap;
 
     /// <summary>
     ///   Initializes a new instance of the <see cref="Entity"/> class.
@@ -29,7 +29,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     public Entity(Guid? uniqueID = null)
     {
         this.UniqueIdentifier = uniqueID ?? Guid.NewGuid();
-        this.typeToComponentMap = new Dictionary<Type, IComponent>();
+        this.typeToComponentMap = new Dictionary<Type, IEntityComponent>();
     }
 
     /// <summary>
@@ -38,7 +38,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     /// <value>
     /// The components attached to this <see cref="Entity"/>.
     /// </value>
-    public ICollection<IComponent> Components
+    public ICollection<IEntityComponent> Components
     {
         get { return this.typeToComponentMap.Values; }
     }
@@ -71,7 +71,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     /// <exception cref="ArgumentException">
     ///   The specified <paramref name="component"/> parameters type has already been added to this entity.
     /// </exception>
-    public void AddComponent(IComponent component)
+    public void AddComponent(IEntityComponent component)
     {
         if (component == null)
         {
@@ -96,7 +96,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     ///   The type component to add to this <see cref="Entity"/>.
     /// </typeparam>
     public void AddComponent<TComponent>()
-        where TComponent : IComponent, new()
+        where TComponent : IEntityComponent, new()
     {
         this.AddComponent(Activator.CreateInstance<TComponent>());
     }
@@ -113,7 +113,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     /// <exception cref="ArgumentNullException">
     ///   The specified <paramref name="component"/> parameter cannot be null.
     /// </exception>
-    public bool ContainsComponent(IComponent component)
+    public bool ContainsComponent(IEntityComponent component)
     {
         if (component == null)
         {
@@ -144,7 +144,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     ///   type - The specified <paramref name="type"/> parameter cannot be null.
     /// </exception>
     /// <exception cref="ArgumentException">
-    ///   The specified <paramref name="type"/> parameter does not implement <see cref="IComponent"/>.
+    ///   The specified <paramref name="type"/> parameter does not implement <see cref="IEntityComponent"/>.
     /// </exception>
     public bool ContainsComponent(Type type)
     {
@@ -153,8 +153,8 @@ public class Entity : DynamicObject, IReadOnlyEntity
             throw new ArgumentNullException(nameof(type));
         }
 
-        return !typeof(IComponent).IsAssignableFrom(type)
-            ? throw new ArgumentException($"The specified {nameof(type)} parameter does not implement {nameof(IComponent)}.", nameof(type))
+        return !typeof(IEntityComponent).IsAssignableFrom(type)
+            ? throw new ArgumentException($"The specified {nameof(type)} parameter does not implement {nameof(IEntityComponent)}.", nameof(type))
             : this.typeToComponentMap.ContainsKey(type);
     }
 
@@ -168,7 +168,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     ///   <c>true</c> if a component of the specified <typeparamref name="TComponent"/> is contained within this <see cref="Entity"/>; otherwise, <c>false</c>.
     /// </returns>
     public bool ContainsComponent<TComponent>()
-        where TComponent : IComponent
+        where TComponent : IEntityComponent
     {
         return this.ContainsComponent(typeof(TComponent));
     }
@@ -186,18 +186,18 @@ public class Entity : DynamicObject, IReadOnlyEntity
     ///   The specified <paramref name="type"/> parameter cannot be null.
     /// </exception>
     /// <exception cref="ArgumentException">
-    ///   The specified <paramref name="type"/> parameter does not implement <see cref="IComponent"/> or the specified <paramref name="type"/> parameter is not a component type that has been added to this <see cref="Entity"/>.
+    ///   The specified <paramref name="type"/> parameter does not implement <see cref="IEntityComponent"/> or the specified <paramref name="type"/> parameter is not a component type that has been added to this <see cref="Entity"/>.
     /// </exception>
-    public IComponent GetComponent(Type type)
+    public IEntityComponent GetComponent(Type type)
     {
         if (type == null)
         {
             throw new ArgumentNullException(nameof(type));
         }
 
-        if (!typeof(IComponent).IsAssignableFrom(type))
+        if (!typeof(IEntityComponent).IsAssignableFrom(type))
         {
-            throw new ArgumentException($"The specified {nameof(type)} parameter does not implement {nameof(IComponent)}.", nameof(type));
+            throw new ArgumentException($"The specified {nameof(type)} parameter does not implement {nameof(IEntityComponent)}.", nameof(type));
         }
 
         return !this.ContainsComponent(type)
@@ -218,7 +218,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     ///   The specified <typeparamref name="TComponent"/> parameter is not a component type that has been added to this <see cref="Entity"/>.
     /// </exception>
     public TComponent GetComponent<TComponent>()
-        where TComponent : IComponent
+        where TComponent : IEntityComponent
     {
         return (TComponent)this.GetComponent(typeof(TComponent));
     }
@@ -235,7 +235,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     /// <exception cref="ArgumentException">
     ///   The specified <paramref name="component"/> parameter has not been added to this entity.
     /// </exception>
-    public void RemoveComponent(IComponent component)
+    public void RemoveComponent(IEntityComponent component)
     {
         if (component == null)
         {
@@ -260,7 +260,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     ///   type - The specified <paramref name="type"/> parameter cannot be null.
     /// </exception>
     /// <exception cref="ArgumentException">
-    ///   The specified <paramref name="type"/> parameter does not implement <see cref="IComponent"/> or the specified <paramref name="type"/> parameter is not a component type that has been added to this entity.
+    ///   The specified <paramref name="type"/> parameter does not implement <see cref="IEntityComponent"/> or the specified <paramref name="type"/> parameter is not a component type that has been added to this entity.
     /// </exception>
     public void RemoveComponent(Type type)
     {
@@ -269,9 +269,9 @@ public class Entity : DynamicObject, IReadOnlyEntity
             throw new ArgumentNullException(nameof(type));
         }
 
-        if (!typeof(IComponent).IsAssignableFrom(type))
+        if (!typeof(IEntityComponent).IsAssignableFrom(type))
         {
-            throw new ArgumentException($"The specified {nameof(type)} parameter does not implement {nameof(IComponent)}.", nameof(type));
+            throw new ArgumentException($"The specified {nameof(type)} parameter does not implement {nameof(IEntityComponent)}.", nameof(type));
         }
 
         if (!this.ContainsComponent(type))
@@ -293,7 +293,7 @@ public class Entity : DynamicObject, IReadOnlyEntity
     ///   A component of the specified <typeparamref name="TComponent"/> parameter has not been added to this entity.
     /// </exception>
     public void RemoveComponent<TComponent>()
-        where TComponent : IComponent
+        where TComponent : IEntityComponent
     {
         this.RemoveComponent(typeof(TComponent));
     }

--- a/FinalEngine.ECS/FinalEngine.ECS.csproj
+++ b/FinalEngine.ECS/FinalEngine.ECS.csproj
@@ -30,7 +30,4 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Attributes\" />
-  </ItemGroup>
 </Project>

--- a/FinalEngine.ECS/FinalEngine.ECS.csproj
+++ b/FinalEngine.ECS/FinalEngine.ECS.csproj
@@ -29,4 +29,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Attributes\" />
+  </ItemGroup>
 </Project>

--- a/FinalEngine.ECS/IEntityComponent.cs
+++ b/FinalEngine.ECS/IEntityComponent.cs
@@ -1,5 +1,5 @@
-// <copyright file="IComponent.cs" company="Software Antics">
-//     Copyright (c) Software Antics. All rights reserved.
+// <copyright file="IEntityComponent.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
 // </copyright>
 
 namespace FinalEngine.ECS;
@@ -10,6 +10,6 @@ using System.Diagnostics.CodeAnalysis;
 ///   Defines an interface that represents a component, which is pure data.
 /// </summary>
 [SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "Components are raw data that should be implemented by the user.")]
-public interface IComponent
+public interface IEntityComponent
 {
 }

--- a/FinalEngine.ECS/IReadOnlyEntity.cs
+++ b/FinalEngine.ECS/IReadOnlyEntity.cs
@@ -20,7 +20,7 @@ public interface IReadOnlyEntity
     /// <returns>
     ///   <c>true</c> if the specified <paramref name="component"/> is contained within this <see cref="IReadOnlyEntity"/>; otherwise, <c>false</c>.
     /// </returns>
-    bool ContainsComponent(IComponent component);
+    bool ContainsComponent(IEntityComponent component);
 
     /// <summary>
     ///   Determines whether a component of the specified <paramref name="type"/> is contained within this <see cref="IReadOnlyEntity"/>.
@@ -43,5 +43,5 @@ public interface IReadOnlyEntity
     ///   <c>true</c> if a component of the specified <typeparamref name="TComponent"/> is contained within this <see cref="IReadOnlyEntity"/>; otherwise, <c>false</c>.
     /// </returns>
     bool ContainsComponent<TComponent>()
-        where TComponent : IComponent;
+        where TComponent : IEntityComponent;
 }

--- a/FinalEngine.Editor.ViewModels/Editing/DataTypes/StringPropertyViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Editing/DataTypes/StringPropertyViewModel.cs
@@ -1,0 +1,20 @@
+// <copyright file="StringPropertyViewModel.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Editing.DataTypes;
+
+using System.Reflection;
+using FinalEngine.ECS;
+
+/// <summary>
+/// Provides an implementation of a <see cref="PropertyViewModel{T}"/> with a generic type of <c>string</c>.
+/// </summary>
+/// <seealso cref="PropertyViewModel{T}"/>
+public sealed class StringPropertyViewModel : PropertyViewModel<string?>
+{
+    public StringPropertyViewModel(IEntityComponent component, PropertyInfo property)
+        : base(component, property)
+    {
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Editing/DataTypes/StringPropertyViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Editing/DataTypes/StringPropertyViewModel.cs
@@ -5,7 +5,6 @@
 namespace FinalEngine.Editor.ViewModels.Editing.DataTypes;
 
 using System.Reflection;
-using FinalEngine.ECS;
 
 /// <summary>
 /// Provides an implementation of a <see cref="PropertyViewModel{T}"/> with a generic type of <c>string</c>.
@@ -13,7 +12,16 @@ using FinalEngine.ECS;
 /// <seealso cref="PropertyViewModel{T}"/>
 public sealed class StringPropertyViewModel : PropertyViewModel<string?>
 {
-    public StringPropertyViewModel(IEntityComponent component, PropertyInfo property)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StringPropertyViewModel"/> class.
+    /// </summary>
+    /// <param name="component">
+    /// The component.
+    /// </param>
+    /// <param name="property">
+    /// The property.
+    /// </param>
+    public StringPropertyViewModel(object component, PropertyInfo property)
         : base(component, property)
     {
     }

--- a/FinalEngine.Editor.ViewModels/Editing/IPropertyViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Editing/IPropertyViewModel.cs
@@ -26,5 +26,5 @@ public interface IPropertyViewModel<T>
     /// <value>
     /// The value of the property.
     /// </value>
-    T Value { get; set; }
+    T? Value { get; set; }
 }

--- a/FinalEngine.Editor.ViewModels/Editing/IPropertyViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Editing/IPropertyViewModel.cs
@@ -1,0 +1,30 @@
+// <copyright file="IPropertyViewModel.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Editing;
+
+/// <summary>
+/// Defines an interface that represents a model of a component property view.
+/// </summary>
+/// <typeparam name="T">
+/// The type of the property to model.
+/// </typeparam>
+public interface IPropertyViewModel<T>
+{
+    /// <summary>
+    /// Gets the name of the property.
+    /// </summary>
+    /// <value>
+    /// The name of the property.
+    /// </value>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets or sets the value of the property.
+    /// </summary>
+    /// <value>
+    /// The value of the property.
+    /// </value>
+    T Value { get; set; }
+}

--- a/FinalEngine.Editor.ViewModels/Editing/PropertyViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Editing/PropertyViewModel.cs
@@ -1,0 +1,80 @@
+// <copyright file="PropertyViewModel.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Editing;
+
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+
+/// <summary>
+/// Provides a standard implementation of an <see cref="IPropertyViewModel{T}"/>.
+/// </summary>
+/// <typeparam name="T">
+/// The type of the property.
+/// </typeparam>
+/// <seealso cref="ObservableObject" />
+/// <seealso cref="IPropertyViewModel{T}"/>
+public sealed class PropertyViewModel<T> : ObservableObject, IPropertyViewModel<T>
+{
+    /// <summary>
+    /// The function used to retrieve the property value.
+    /// </summary>
+    private readonly Func<T> getValue;
+
+    /// <summary>
+    /// The action used to set the property value.
+    /// </summary>
+    private readonly Action<T> setValue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyViewModel{T}"/> class.
+    /// </summary>
+    /// <param name="name">
+    /// The name of the property.
+    /// </param>
+    /// <param name="getValue">
+    /// The function used to retrieve the property value.
+    /// </param>
+    /// <param name="setValue">
+    /// The function used to set the property value.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// The specified <paramref name="name"/> parameter cannot be null or whitespace.
+    /// </exception>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="getValue"/> or <paramref name="setValue"/> parameter cannot be null.
+    /// </exception>
+    public PropertyViewModel(string name, Func<T> getValue, Action<T> setValue)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException($"'{nameof(name)}' cannot be null or whitespace.", nameof(name));
+        }
+
+        this.getValue = getValue ?? throw new ArgumentNullException(nameof(getValue));
+        this.setValue = setValue ?? throw new ArgumentNullException(nameof(setValue));
+
+        this.Name = name;
+        this.Value = getValue();
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public T Value
+    {
+        get
+        {
+            return this.getValue();
+        }
+
+        set
+        {
+            this.OnPropertyChanging(nameof(this.Value));
+            this.setValue(value);
+            this.OnPropertyChanged(nameof(this.Value));
+        }
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Editing/PropertyViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Editing/PropertyViewModel.cs
@@ -16,7 +16,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 /// </typeparam>
 /// <seealso cref="ObservableObject" />
 /// <seealso cref="IPropertyViewModel{T}"/>
-public abstract class PropertyViewModel<T> : ObservableObject, IPropertyViewModel<T>
+public class PropertyViewModel<T> : ObservableObject, IPropertyViewModel<T>
 {
     /// <summary>
     /// The object that contains the property.
@@ -42,7 +42,7 @@ public abstract class PropertyViewModel<T> : ObservableObject, IPropertyViewMode
     /// <param name="property">
     /// The property.
     /// </param>
-    protected PropertyViewModel(object component, PropertyInfo property)
+    public PropertyViewModel(object component, PropertyInfo property)
     {
         if (property == null)
         {

--- a/FinalEngine.Editor.ViewModels/Editing/PropertyViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Editing/PropertyViewModel.cs
@@ -36,6 +36,12 @@ public abstract class PropertyViewModel<T> : ObservableObject, IPropertyViewMode
     /// <summary>
     /// Initializes a new instance of the <see cref="PropertyViewModel{T}"/> class.
     /// </summary>
+    /// <param name="component">
+    /// The object that contains the property.
+    /// </param>
+    /// <param name="property">
+    /// The property.
+    /// </param>
     protected PropertyViewModel(object component, PropertyInfo property)
     {
         if (property == null)

--- a/FinalEngine.Editor.ViewModels/Exceptions/Inspectors/PropertyTypeNotFoundException.cs
+++ b/FinalEngine.Editor.ViewModels/Exceptions/Inspectors/PropertyTypeNotFoundException.cs
@@ -1,0 +1,74 @@
+// <copyright file="PropertyTypeNotFoundException.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Exceptions.Inspectors;
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
+
+/// <summary>
+/// Provides an exception that is thrown when a property type cannot be found.
+/// </summary>
+/// <seealso cref="Exception" />
+[Serializable]
+[ExcludeFromCodeCoverage(Justification = "Exception")]
+public class PropertyTypeNotFoundException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyTypeNotFoundException"/> class.
+    /// </summary>
+    public PropertyTypeNotFoundException()
+        : base("A property tpye was not found.")
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyTypeNotFoundException"/> class.
+    /// </summary>
+    /// <param name="typeName">
+    /// The name of the property type.
+    /// </param>
+    public PropertyTypeNotFoundException(string? typeName)
+        : base($"A property type of name: '{typeName}' was not found.")
+    {
+        this.TypeName = typeName;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyTypeNotFoundException"/> class.
+    /// </summary>
+    /// <param name="message">
+    /// The error message that explains the reason for the exception.
+    /// </param>
+    /// <param name="innerException">
+    /// The exception that is the cause of the current exception, or a null reference in Visual Basic) if no inner exception is specified.
+    /// </param>
+    public PropertyTypeNotFoundException(string? message, Exception? innerException)
+        : base(message, innerException)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PropertyTypeNotFoundException"/> class.
+    /// </summary>
+    /// <param name="info">
+    /// The <see cref="SerializationInfo" /> that holds the serialized object data about the exception being thrown.
+    /// </param>
+    /// <param name="context">
+    /// The <see cref="StreamingContext" /> that contains contextual information about the source or destination.
+    /// </param>
+    protected PropertyTypeNotFoundException(SerializationInfo info, StreamingContext context)
+        : base(info, context)
+    {
+    }
+
+    /// <summary>
+    /// Gets the name of the property type that could not be found.
+    /// </summary>
+    /// <value>
+    /// The name of the property type that could not be found and caused the exception to be thrown.
+    /// </value>
+    public string? TypeName { get; }
+}

--- a/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
+++ b/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
@@ -8,6 +8,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Platforms>x64</Platforms>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
+++ b/FinalEngine.Editor.ViewModels/FinalEngine.Editor.ViewModels.csproj
@@ -8,7 +8,6 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Platforms>x64</Platforms>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FinalEngine.Editor.ViewModels/Inspectors/EntityComponentViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/EntityComponentViewModel.cs
@@ -45,7 +45,6 @@ public sealed class EntityComponentViewModel : ObservableObject, IEntityComponen
 
         this.Name = component.GetType().Name;
 
-        //// TODO: Only use public properties and also consider attributes (what if the user wants to use a private property or field).
         foreach (var property in component.GetType().GetProperties())
         {
             var type = property.PropertyType;

--- a/FinalEngine.Editor.ViewModels/Inspectors/EntityComponentViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/EntityComponentViewModel.cs
@@ -1,0 +1,99 @@
+// <copyright file="EntityComponentViewModel.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Inspectors;
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Reflection;
+using CommunityToolkit.Mvvm.ComponentModel;
+using FinalEngine.ECS;
+using FinalEngine.Editor.ViewModels.Editing;
+
+/// <summary>
+/// Provides a standard implementation of an <see cref="IEntityComponentViewModel"/>.
+/// </summary>
+/// <seealso cref="ObservableObject" />
+/// <seealso cref="IEntityComponentViewModel" />
+public sealed class EntityComponentViewModel : ObservableObject, IEntityComponentViewModel
+{
+    /// <summary>
+    /// The component that is being modelled.
+    /// </summary>
+    private readonly IComponent component;
+
+    /// <summary>
+    /// The property view models associated with this component model.
+    /// </summary>
+    private readonly ObservableCollection<ObservableObject> propertyViewModels;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityComponentViewModel"/> class.
+    /// </summary>
+    /// <param name="component">
+    /// The component to be modelled.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="component"/> parameter cannot be null.
+    /// </exception>
+    public EntityComponentViewModel(IComponent component)
+    {
+        this.component = component ?? throw new ArgumentNullException(nameof(component));
+        this.propertyViewModels = new ObservableCollection<ObservableObject>();
+
+        this.Name = component.GetType().Name;
+
+        //// TODO: Only use public properties and also consider attributes (what if the user wants to use a private property or field).
+        foreach (var property in component.GetType().GetProperties())
+        {
+            string name = property.Name;
+            var type = property.PropertyType;
+
+            switch (type.Name.ToUpperInvariant())
+            {
+                case "STRING":
+                    this.AddProperty<string?>(property);
+                    break;
+
+                default:
+                    //// TODO: Throw an exception or log?
+                    break;
+            }
+        }
+    }
+
+    /// <inheritdoc/>
+    public string Name { get; }
+
+    /// <inheritdoc/>
+    public ICollection<ObservableObject> PropertyViewModels
+    {
+        get { return this.propertyViewModels; }
+    }
+
+    /// <summary>
+    /// Adds a <see cref="PropertyViewModel{T}"/> of type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T">
+    /// The type of property to add.
+    /// </typeparam>
+    /// <param name="property">
+    /// The property.
+    /// </param>
+    private void AddProperty<T>(PropertyInfo property)
+    {
+        var getValue = new Func<T?>(() =>
+        {
+            return (T?)property.GetValue(this.component);
+        });
+
+        var setValue = new Action<T?>(x =>
+        {
+            property.SetValue(this.component, x);
+        });
+
+        this.propertyViewModels.Add(new PropertyViewModel<T?>(property.Name, getValue, setValue));
+    }
+}

--- a/FinalEngine.Editor.ViewModels/Inspectors/EntityComponentViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/EntityComponentViewModel.cs
@@ -12,6 +12,7 @@ using System.Reflection;
 using CommunityToolkit.Mvvm.ComponentModel;
 using FinalEngine.ECS;
 using FinalEngine.Editor.ViewModels.Editing.DataTypes;
+using FinalEngine.Editor.ViewModels.Exceptions.Inspectors;
 
 /// <summary>
 /// Provides a standard implementation of an <see cref="IEntityComponentViewModel"/>.
@@ -62,8 +63,7 @@ public sealed class EntityComponentViewModel : ObservableObject, IEntityComponen
                     break;
 
                 default:
-                    //// TODO: Log a warning message here.
-                    break;
+                    throw new PropertyTypeNotFoundException(this.Name);
             }
         }
     }

--- a/FinalEngine.Editor.ViewModels/Inspectors/EntityInspectorViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/EntityInspectorViewModel.cs
@@ -4,7 +4,11 @@
 
 namespace FinalEngine.Editor.ViewModels.Inspectors;
 
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
+using FinalEngine.ECS;
 
 /// <summary>
 /// Provides a standard implementation of an <see cref="IEntityInspectorViewModel"/>.
@@ -13,4 +17,39 @@ using CommunityToolkit.Mvvm.ComponentModel;
 /// <seealso cref="IEntityInspectorViewModel" />
 public sealed class EntityInspectorViewModel : ObservableObject, IEntityInspectorViewModel
 {
+    /// <summary>
+    /// The component view models.
+    /// </summary>
+    private readonly ObservableCollection<IEntityComponentViewModel> componentViewModels;
+
+    /// <summary>
+    /// The entity being inspected.
+    /// </summary>
+    private readonly Entity entity;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EntityInspectorViewModel"/> class.
+    /// </summary>
+    /// <param name="entity">
+    /// The entity to be inspected.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// The specified <paramref name="entity"/> parameter cannot be null.
+    /// </exception>
+    public EntityInspectorViewModel(Entity entity)
+    {
+        this.entity = entity ?? throw new ArgumentNullException(nameof(entity));
+        this.componentViewModels = new ObservableCollection<IEntityComponentViewModel>();
+
+        foreach (var component in this.entity.Components)
+        {
+            this.componentViewModels.Add(new EntityComponentViewModel(component));
+        }
+    }
+
+    /// <inheritdoc/>
+    public ICollection<IEntityComponentViewModel> ComponentViewModels
+    {
+        get { return this.componentViewModels; }
+    }
 }

--- a/FinalEngine.Editor.ViewModels/Inspectors/IEntityComponentViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/IEntityComponentViewModel.cs
@@ -14,10 +14,10 @@ using FinalEngine.ECS;
 public interface IEntityComponentViewModel
 {
     /// <summary>
-    /// Gets the name of the <see cref="IComponent"/>.
+    /// Gets the name of the <see cref="IEntityComponent"/>.
     /// </summary>
     /// <value>
-    /// The name of the <see cref="IComponent"/>.
+    /// The name of the <see cref="IEntityComponent"/>.
     /// </value>
     string Name { get; }
 

--- a/FinalEngine.Editor.ViewModels/Inspectors/IEntityComponentViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/IEntityComponentViewModel.cs
@@ -1,0 +1,31 @@
+// <copyright file="IEntityComponentViewModel.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Inspectors;
+
+using System.Collections.Generic;
+using CommunityToolkit.Mvvm.ComponentModel;
+using FinalEngine.ECS;
+
+/// <summary>
+/// Defines an interface that represents a model of an entity component view.
+/// </summary>
+public interface IEntityComponentViewModel
+{
+    /// <summary>
+    /// Gets the name of the <see cref="IComponent"/>.
+    /// </summary>
+    /// <value>
+    /// The name of the <see cref="IComponent"/>.
+    /// </value>
+    string Name { get; }
+
+    /// <summary>
+    /// Gets the property view models.
+    /// </summary>
+    /// <value>
+    /// The property view models.
+    /// </value>
+    ICollection<ObservableObject> PropertyViewModels { get; }
+}

--- a/FinalEngine.Editor.ViewModels/Inspectors/IEntityInspectorViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/IEntityInspectorViewModel.cs
@@ -4,12 +4,18 @@
 
 namespace FinalEngine.Editor.ViewModels.Inspectors;
 
-using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
 
 /// <summary>
 /// Defines an interface that represents a model of the entity inspector view.
 /// </summary>
-[SuppressMessage("Design", "CA1040:Avoid empty interfaces", Justification = "TODO")]
 public interface IEntityInspectorViewModel
 {
+    /// <summary>
+    /// Gets the component view models.
+    /// </summary>
+    /// <value>
+    /// The component view models.
+    /// </value>
+    ICollection<IEntityComponentViewModel> ComponentViewModels { get; }
 }

--- a/FinalEngine.Editor.ViewModels/Inspectors/PropertiesToolViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/PropertiesToolViewModel.cs
@@ -52,7 +52,7 @@ public sealed class PropertiesToolViewModel : ToolViewModelBase, IPropertiesTool
         this.Title = "Properties";
         this.ContentID = "Properties";
 
-        logger.LogInformation($"Initializing {this.Title}...");
+        this.logger.LogInformation($"Initializing {this.Title}...");
 
         this.messenger.Register<EntitySelectedMessage>(this, this.HandleEntitySelected);
     }

--- a/FinalEngine.Editor.ViewModels/Inspectors/PropertiesToolViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/PropertiesToolViewModel.cs
@@ -80,9 +80,7 @@ public sealed class PropertiesToolViewModel : ToolViewModelBase, IPropertiesTool
     {
         this.logger.LogInformation($"Changing properties view to: '{nameof(EntityInspectorViewModel)}'.");
 
-        var entity = message.Entity;
-
         this.Title = "Entity Inspector";
-        this.CurrentViewModel = new EntityInspectorViewModel();
+        this.CurrentViewModel = new EntityInspectorViewModel(message.Entity);
     }
 }

--- a/FinalEngine.Tests/ECS/EntityTests.cs
+++ b/FinalEngine.Tests/ECS/EntityTests.cs
@@ -514,15 +514,15 @@ public class EntityTests
         }
     }
 
-    private sealed class MockComponent : IComponent
+    private sealed class MockComponent : IEntityComponent
     {
     }
 
-    private sealed class MockComponentA : IComponent
+    private sealed class MockComponentA : IEntityComponent
     {
     }
 
-    private sealed class MockComponentB : IComponent
+    private sealed class MockComponentB : IEntityComponent
     {
     }
 }

--- a/FinalEngine.Tests/Editor/ViewModels/Editing/PropertyViewModelTests.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Editing/PropertyViewModelTests.cs
@@ -1,0 +1,84 @@
+// <copyright file="PropertyViewModelTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels.Editing;
+
+using System;
+using FinalEngine.Editor.ViewModels.Editing;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class PropertyViewModelTests
+{
+    private PropertyViewModel<string> viewModel;
+
+    public string ComponentProperty { get; set; }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenComponentIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new PropertyViewModel<string>(null, this.GetType().GetProperty(nameof(this.ComponentProperty)));
+        });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenPropertyIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new PropertyViewModel<string>(this, null);
+        });
+    }
+
+    [Test]
+    public void NameShouldReturnPropertyNameWhenInvoked()
+    {
+        // Arrange
+        string expected = nameof(this.ComponentProperty);
+
+        // Act
+        string actual = this.viewModel.Name;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.ComponentProperty = "Hello, World!";
+        this.viewModel = new PropertyViewModel<string>(this, this.GetType().GetProperty(nameof(this.ComponentProperty)));
+    }
+
+    [Test]
+    public void ValueShouldReturnHelloWorldWhenInvoked()
+    {
+        // Arrange
+        const string expected = "Hello, World!";
+
+        // Act
+        string actual = this.viewModel.Value;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ValueShouldReturnTestWhenSetToTest()
+    {
+        // Arrange
+        const string expceted = "Test";
+        this.viewModel.Value = expceted;
+
+        // Act
+        string actual = this.viewModel.Value;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expceted));
+    }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/Inspectors/EntityComponentViewModelTests.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Inspectors/EntityComponentViewModelTests.cs
@@ -1,0 +1,97 @@
+// <copyright file="EntityComponentViewModelTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels.Inspectors;
+
+using System;
+using FinalEngine.ECS.Components.Core;
+using FinalEngine.Editor.ViewModels.Exceptions.Inspectors;
+using FinalEngine.Editor.ViewModels.Inspectors;
+using FinalEngine.Tests.Editor.ViewModels.Inspectors.Mocks;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class EntityComponentViewModelTests
+{
+    private TagComponent component;
+
+    private EntityComponentViewModel viewModel;
+
+    [Test]
+    public void ConstructorShouldAddPropertyViewModelWhenComponentDoesNotHaveBrowsableAttribute()
+    {
+        // Assert
+        Assert.That(this.viewModel.PropertyViewModels, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ConstructorShouldAddPropertyViewModelWhenComponentIsBrowseable()
+    {
+        // Arrange
+        var component = new EntityComponentBrowsable();
+
+        // Act
+        var viewModel = new EntityComponentViewModel(component);
+
+        // Assert
+        Assert.That(viewModel.PropertyViewModels, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void ConstructorShouldNotAddPropertyViewModelWhenComponentNotBrowseable()
+    {
+        // Arrange
+        var component = new EntityComponentNotBrowsable();
+
+        // Act
+        var viewModel = new EntityComponentViewModel(component);
+
+        // Assert
+        Assert.That(viewModel.PropertyViewModels, Is.Empty);
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenComponentIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new EntityComponentViewModel(null);
+        });
+    }
+
+    [Test]
+    public void ConstructorShouldThrowPropertyTypeNotFoundExceptionWhenPropertyTypeIsNotSupported()
+    {
+        // Act and assert
+        Assert.Throws<PropertyTypeNotFoundException>(() =>
+        {
+            new EntityComponentViewModel(new EntityComponentUnsupportedPropertyType());
+        });
+    }
+
+    [Test]
+    public void NameShouldReturnTagComponentWhenInvoked()
+    {
+        // Arrange
+        string expected = this.component.GetType().Name;
+
+        // Act
+        string actual = this.viewModel.Name;
+
+        // Assert
+        Assert.That(actual, Is.EqualTo(expected));
+    }
+
+    [OneTimeSetUp]
+    public void Setup()
+    {
+        this.component = new TagComponent()
+        {
+            Tag = "Tag",
+        };
+
+        this.viewModel = new EntityComponentViewModel(this.component);
+    }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/Inspectors/EntityInspectorViewModelTests.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Inspectors/EntityInspectorViewModelTests.cs
@@ -1,0 +1,63 @@
+// <copyright file="EntityInspectorViewModelTests.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels.Inspectors;
+
+using System;
+using System.Linq;
+using FinalEngine.ECS;
+using FinalEngine.ECS.Components.Core;
+using FinalEngine.Editor.ViewModels.Inspectors;
+using NUnit.Framework;
+
+[TestFixture]
+public sealed class EntityInspectorViewModelTests
+{
+    private Entity entity;
+
+    private EntityInspectorViewModel viewModel;
+
+    [Test]
+    public void ComponentViewModelsShouldNotReturnNull()
+    {
+        // Act
+        var actual = this.viewModel.ComponentViewModels;
+
+        // Assert
+        Assert.That(actual, Is.Not.Null);
+    }
+
+    [Test]
+    public void ComponentViewModelsShouldReturnEntityComponentViewModels()
+    {
+        // Act
+        var actual = this.viewModel.ComponentViewModels.FirstOrDefault();
+
+        // Assert
+        Assert.That(actual, Is.AssignableFrom<EntityComponentViewModel>());
+    }
+
+    [Test]
+    public void ConstructorShouldThrowArgumentNullExceptionWhenEntityIsNull()
+    {
+        // Act and assert
+        Assert.Throws<ArgumentNullException>(() =>
+        {
+            new EntityInspectorViewModel(null);
+        });
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        this.entity = new Entity();
+
+        this.entity.AddComponent(new TagComponent()
+        {
+            Tag = "Tag",
+        });
+
+        this.viewModel = new EntityInspectorViewModel(this.entity);
+    }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/Inspectors/Mocks/EntityComponentBrowsable.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Inspectors/Mocks/EntityComponentBrowsable.cs
@@ -1,0 +1,14 @@
+// <copyright file="EntityComponentBrowsable.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels.Inspectors.Mocks;
+
+using System.ComponentModel;
+using FinalEngine.ECS;
+
+public sealed class EntityComponentBrowsable : IEntityComponent
+{
+    [Browsable(true)]
+    public string Test { get; set; }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/Inspectors/Mocks/EntityComponentNotBrowsable.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Inspectors/Mocks/EntityComponentNotBrowsable.cs
@@ -1,0 +1,14 @@
+// <copyright file="EntityComponentNotBrowsable.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels.Inspectors.Mocks;
+
+using System.ComponentModel;
+using FinalEngine.ECS;
+
+public sealed class EntityComponentNotBrowsable : IEntityComponent
+{
+    [Browsable(false)]
+    public string Test { get; set; }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/Inspectors/Mocks/EntityComponentUnsupportedPropertyType.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Inspectors/Mocks/EntityComponentUnsupportedPropertyType.cs
@@ -1,0 +1,12 @@
+// <copyright file="EntityComponentUnsupportedPropertyType.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels.Inspectors.Mocks;
+
+using FinalEngine.ECS;
+
+public sealed class EntityComponentUnsupportedPropertyType : IEntityComponent
+{
+    public object Test { get; set; }
+}

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3150.0")]
-[assembly: AssemblyFileVersion("2023.3.3148.0")]
+[assembly: AssemblyVersion("2023.3.3160.0")]
+[assembly: AssemblyFileVersion("2023.3.3158.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3143.0")]
-[assembly: AssemblyFileVersion("2023.3.3142.0")]
+[assembly: AssemblyVersion("2023.3.3150.0")]
+[assembly: AssemblyFileVersion("2023.3.3148.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3191.0")]
-[assembly: AssemblyFileVersion("2023.3.3189.0")]
+[assembly: AssemblyVersion("2023.3.3377.0")]
+[assembly: AssemblyFileVersion("2023.3.3375.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3160.0")]
-[assembly: AssemblyFileVersion("2023.3.3158.0")]
+[assembly: AssemblyVersion("2023.3.3163.0")]
+[assembly: AssemblyFileVersion("2023.3.3161.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3118.0")]
-[assembly: AssemblyFileVersion("2023.3.3117.0")]
+[assembly: AssemblyVersion("2023.3.3143.0")]
+[assembly: AssemblyFileVersion("2023.3.3142.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3163.0")]
-[assembly: AssemblyFileVersion("2023.3.3161.0")]
+[assembly: AssemblyVersion("2023.3.3191.0")]
+[assembly: AssemblyFileVersion("2023.3.3189.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3028.0")]
-[assembly: AssemblyFileVersion("2023.3.3027.0")]
+[assembly: AssemblyVersion("2023.3.3118.0")]
+[assembly: AssemblyFileVersion("2023.3.3117.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else


### PR DESCRIPTION
# Description

- Created a generic `PropertyViewModel` to inherit from whenever a new property type is supported by the entity inspector.
- Created an `EntityComponentViewModel` which will show all components that are supported
- Throws a `PropertyTypeNotFoundException` when a property type is not supported for an entity component. To avoid this, use the `BrowsableAttribute`.
- Updated `EntityInspectorViewModel` to have a collection of `EntityComponentViewModel`s. This will be used to generate a collection of component view models to be viewed within the inspector.
- I only added one property type to be supported: `StringPropertyViewModel` as the only component we currently have is `TagComponent`.

Fixes #260 

## Dependencies

This PR introduces no new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I added unit tests to accommodate my changes. _Final Code Coverage_ is showing 99.8% code coverage. I ensured that the editor still worked as expected when adding and deleting entities - When selecting an entity the entity inspector is shown but #261 is still yet to be completed to show the components with the selected entity.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ, 16GB, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
