### PR TITLE
✨ Entity Renaming in Entity Inspector should update Scene Hierarchy

### DIFF
--- a/FinalEngine.ECS.Components/Core/TagComponent.cs
+++ b/FinalEngine.ECS.Components/Core/TagComponent.cs
@@ -4,17 +4,46 @@
 
 namespace FinalEngine.ECS.Components.Core;
 
+using System.ComponentModel;
+
 /// <summary>
 /// Provides a component that represents a name or tag for an <see cref="Entity"/>.
 /// </summary>
 /// <seealso cref="IEntityComponent" />
-public sealed class TagComponent : IEntityComponent
+public sealed class TagComponent : IEntityComponent, INotifyPropertyChanged
 {
+    /// <summary>
+    /// The tag.
+    /// </summary>
+    private string? tag;
+
+    /// <summary>
+    /// Occurs when a property value changes.
+    /// </summary>
+    public event PropertyChangedEventHandler? PropertyChanged;
+
     /// <summary>
     /// Gets or sets the tag.
     /// </summary>
     /// <value>
     /// The tag.
     /// </value>
-    public string? Tag { get; set; }
+    public string? Tag
+    {
+        get
+        {
+            return this.tag;
+        }
+
+        set
+        {
+            if (this.tag == value)
+            {
+                return;
+            }
+
+            this.tag = value;
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(this.Tag)));
+        }
+    }
 }

--- a/FinalEngine.Editor.Desktop/Views/Scenes/SceneHierarchyView.xaml
+++ b/FinalEngine.Editor.Desktop/Views/Scenes/SceneHierarchyView.xaml
@@ -36,7 +36,7 @@
 
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Text="{Binding TagComponent.Tag}" />
+                    <TextBlock Text="{Binding TagComponent.Tag, UpdateSourceTrigger=PropertyChanged}" />
                 </DataTemplate>
             </ListBox.ItemTemplate>
         </ListBox>


### PR DESCRIPTION
# Description

- `TagComponent` now implements `INotifyPropertyChanged`. This is unusual but considered okay in this specific context.
  - All other instances of components will not need to interact directly with the UI.
- `UpdateSourceTrigger` has been changed to `PropertyChanged`.

Fixes #267 

## Dependencies

This PR introduces no new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

No unit tests have been provided because an issue has been added to the backlog to address the fact that we are implementing `INotifyPropertyChanged` on a model instead of a view model.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
