### PR TITLE
✨ Update the `CurrentViewModel` of `PropertiesView` to be `null` when an `Entity` is deleted.

### DIFF
--- a/FinalEngine.Editor.ViewModels/Inspectors/PropertiesToolViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Inspectors/PropertiesToolViewModel.cs
@@ -55,6 +55,7 @@ public sealed class PropertiesToolViewModel : ToolViewModelBase, IPropertiesTool
         this.logger.LogInformation($"Initializing {this.Title}...");
 
         this.messenger.Register<EntitySelectedMessage>(this, this.HandleEntitySelected);
+        this.messenger.Register<EntityDeletedMessage>(this, this.HandleEntityDeleted);
     }
 
     /// <inheritdoc/>
@@ -62,6 +63,20 @@ public sealed class PropertiesToolViewModel : ToolViewModelBase, IPropertiesTool
     {
         get { return this.currentViewModel; }
         private set { this.SetProperty(ref this.currentViewModel, value); }
+    }
+
+    /// <summary>
+    /// Handles the <see cref="EntityDeletedMessage"/> and resets the view.
+    /// </summary>
+    /// <param name="recipient">
+    /// The recipient.
+    /// </param>
+    /// <param name="message">
+    /// The message.
+    /// </param>
+    private void HandleEntityDeleted(object recipient, EntityDeletedMessage message)
+    {
+        this.ResetCurrentViewModel();
     }
 
     /// <summary>
@@ -82,5 +97,16 @@ public sealed class PropertiesToolViewModel : ToolViewModelBase, IPropertiesTool
 
         this.Title = "Entity Inspector";
         this.CurrentViewModel = new EntityInspectorViewModel(message.Entity);
+    }
+
+    /// <summary>
+    /// Resets the current view model.
+    /// </summary>
+    private void ResetCurrentViewModel()
+    {
+        this.logger.LogInformation($"Reseting the properties view to: `{nameof(PropertiesToolViewModel)}`.");
+
+        this.Title = "Properties";
+        this.CurrentViewModel = null;
     }
 }

--- a/FinalEngine.Editor.ViewModels/Messages/Entities/EntityDeletedMessage.cs
+++ b/FinalEngine.Editor.ViewModels/Messages/Entities/EntityDeletedMessage.cs
@@ -1,0 +1,14 @@
+// <copyright file="EntityDeletedMessage.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Editor.ViewModels.Messages.Entities;
+
+using FinalEngine.ECS;
+
+/// <summary>
+/// Provides a message that should be published when an <see cref="Entity"/> is deleted.
+/// </summary>
+public sealed class EntityDeletedMessage
+{
+}

--- a/FinalEngine.Editor.ViewModels/Scenes/SceneHierarchyToolViewModel.cs
+++ b/FinalEngine.Editor.ViewModels/Scenes/SceneHierarchyToolViewModel.cs
@@ -130,5 +130,6 @@ public sealed class SceneHierarchyToolViewModel : ToolViewModelBase, ISceneHiera
         }
 
         this.sceneManager.ActiveScene.RemoveEntity(this.SelectedEntity.UniqueIdentifier);
+        this.messenger.Send(new EntityDeletedMessage());
     }
 }

--- a/FinalEngine.Tests/Editor/ViewModels/Inspectors/PropertiesToolViewModelTests.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Inspectors/PropertiesToolViewModelTests.cs
@@ -22,6 +22,20 @@ public sealed class PropertiesToolViewModelTests
     private PropertiesToolViewModel viewModel;
 
     [Test]
+    public void COnstructorShouldRegisterEntityDeletedMessageWhenInvoked()
+    {
+        // Assert
+        Assert.That(WeakReferenceMessenger.Default.IsRegistered<EntityDeletedMessage>(this.viewModel), Is.True);
+    }
+
+    [Test]
+    public void ConstructorShouldRegisterEntitySelectedMessageWhenInvoked()
+    {
+        // Assert
+        Assert.That(WeakReferenceMessenger.Default.IsRegistered<EntitySelectedMessage>(this.viewModel), Is.True);
+    }
+
+    [Test]
     public void ConstructorShouldSetContentIDToSceneViewWhenInvoked()
     {
         // Arrange
@@ -97,6 +111,26 @@ public sealed class PropertiesToolViewModelTests
 
         // Assert
         Assert.That(this.viewModel.Title, Is.EqualTo("Entity Inspector"));
+    }
+
+    [Test]
+    public void MessengerSendEntityDeletedMessageShouldResetCurrentViewModelWhenInvoked()
+    {
+        // Act
+        WeakReferenceMessenger.Default.Send(new EntityDeletedMessage());
+
+        // Assert
+        Assert.That(this.viewModel.CurrentViewModel, Is.Null);
+    }
+
+    [Test]
+    public void MessengerSendEntityDeletedMessageShouldResetTitleToPropertiesWhenInvoked()
+    {
+        // Act
+        WeakReferenceMessenger.Default.Send(new EntityDeletedMessage());
+
+        // Assert
+        Assert.That(this.viewModel.Title, Is.EqualTo("Properties"));
     }
 
     [SetUp]

--- a/FinalEngine.Tests/Editor/ViewModels/Messages/IsAnyToken.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Messages/IsAnyToken.cs
@@ -1,0 +1,37 @@
+// <copyright file="IsAnyToken.cs" company="Software Antics">
+// Copyright (c) Software Antics. All rights reserved.
+// </copyright>
+
+namespace FinalEngine.Tests.Editor.ViewModels.Messages;
+
+using System;
+using Moq;
+
+[TypeMatcher]
+public sealed class IsAnyToken : ITypeMatcher, IEquatable<IsAnyToken>
+{
+    public bool Equals(IsAnyToken other)
+    {
+        if (other == null)
+        {
+            return false;
+        }
+
+        return ReferenceEquals(this, other);
+    }
+
+    public override bool Equals(object obj)
+    {
+        return this.Equals(obj as IsAnyToken);
+    }
+
+    public override int GetHashCode()
+    {
+        return base.GetHashCode();
+    }
+
+    public bool Matches(Type typeArgument)
+    {
+        return true;
+    }
+}

--- a/FinalEngine.Tests/Editor/ViewModels/Scenes/SceneHierarchyToolViewModelTests.cs
+++ b/FinalEngine.Tests/Editor/ViewModels/Scenes/SceneHierarchyToolViewModelTests.cs
@@ -6,11 +6,14 @@ namespace FinalEngine.Tests.Editor.ViewModels.Scenes;
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using CommunityToolkit.Mvvm.Messaging;
 using FinalEngine.ECS;
 using FinalEngine.Editor.Common.Models.Scenes;
 using FinalEngine.Editor.Common.Services.Scenes;
+using FinalEngine.Editor.ViewModels.Messages.Entities;
 using FinalEngine.Editor.ViewModels.Scenes;
+using FinalEngine.Tests.Editor.ViewModels.Messages;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -110,6 +113,19 @@ public sealed class SceneHierarchyToolViewModelTests
     }
 
     [Test]
+    public void DeleteEntityCommandShouldInvokeMessengerSendEntityDeletedMessageWhenInvoked()
+    {
+        // Arrange
+        this.viewModel.SelectedEntity = this.entities.First();
+
+        // Act
+        this.viewModel.DeleteEntityCommand.Execute(null);
+
+        // Assert
+        this.messenger.Verify(x => x.Send(It.IsAny<EntityDeletedMessage>(), It.IsAny<IsAnyToken>()), Times.Once);
+    }
+
+    [Test]
     public void DeleteEntityCommandShouldInvokeSceneRemoveEntityWhenSelectedEntityIsNotNull()
     {
         // Arrange
@@ -140,6 +156,19 @@ public sealed class SceneHierarchyToolViewModelTests
 
         // Assert
         Assert.That(actual, Is.SameAs(this.entities));
+    }
+
+    [Test]
+    public void SelectedEntityShouldInvokeMessengerSendEntitySelectedMessageWhenEntityChanged()
+    {
+        // Arrange
+        var entity = new Entity();
+
+        // Act
+        this.viewModel.SelectedEntity = entity;
+
+        // Assert
+        this.messenger.Verify(x => x.Send(It.IsAny<EntitySelectedMessage>(), It.IsAny<IsAnyToken>()), Times.Once);
     }
 
     [Test]

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3377.0")]
-[assembly: AssemblyFileVersion("2023.3.3375.0")]
+[assembly: AssemblyVersion("2023.3.3395.0")]
+[assembly: AssemblyFileVersion("2023.3.3393.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -9,8 +9,8 @@ using System.Reflection;
 [assembly: AssemblyCopyright("© 2023 Software Antics")]
 [assembly: AssemblyTrademark("Software Antics™")]
 [assembly: AssemblyCulture("")]
-[assembly: AssemblyVersion("2023.3.3395.0")]
-[assembly: AssemblyFileVersion("2023.3.3393.0")]
+[assembly: AssemblyVersion("2023.3.3412.0")]
+[assembly: AssemblyFileVersion("2023.3.3410.0")]
 #if DEBUG
 [assembly: AssemblyConfiguration("Debug")]
 #else


### PR DESCRIPTION
# Description

- Created an `EntityDeletedMessage` that is published when an entity is deleted from the scene hierarchy.
- Reset the `PropertiesView` to it's default state when an `EntityDeletedMessage` is published.

Fixes #270 

## Dependencies

This PR introduces no new dependencies.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?

I added unit tests to accommodate my changes and ensured that upon deleting an entity via the right click context menu that the `PropertiesView` is reset.

**Test Configuration**:
* Operating System: Windows 10 Home
* Hardware: Intel i7-6700HQ, 16GB, GTX 950M
* Toolchain: VS Community 2022 17.5.4

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings
